### PR TITLE
PC-377: Fix supplier showing up on the contact details page

### DIFF
--- a/help_to_heat/templates/frontdoor/contact-details.html
+++ b/help_to_heat/templates/frontdoor/contact-details.html
@@ -14,7 +14,7 @@
         </h1>
       </legend>
       <p class="govuk-body">
-        The details entered below will be used by Utility Warehouse and their subcontractors to review your referral and provide
+        The details entered below will be used by {{supplier}} and their subcontractors to review your referral and provide
         you with relevant updates. Emails will be used to provide you with updates and telephone calls to discuss measure
         details.
       </p>


### PR DESCRIPTION
Previously only showed Utility warehouse regardless of supplier selection