### PR TITLE
PC-350: Add role and tabindex to feedback anchor tag

### DIFF
--- a/help_to_heat/templates/frontdoor/base.html
+++ b/help_to_heat/templates/frontdoor/base.html
@@ -88,13 +88,13 @@
   </header>
   <div class="govuk-width-container app-width-container">
 
-    <div class="govuk-phase-banner" role="banner">
+    <div class="govuk-phase-banner">
       <p class="govuk-phase-banner__content">
         <strong class="govuk-tag govuk-phase-banner__content__tag">
           BETA
         </strong>
         <span class="govuk-phase-banner__text">
-          This is a new service – your <a class="govuk-link" href="{% if session_id and page_name %}{{url('frontdoor:feedback', session_id=session_id, page_name=page_name)}}{% else %}{{url('frontdoor:feedback')}}{% endif %}">feedback</a> will help us to improve it.
+          This is a new service – your <a class="govuk-link" href="{% if session_id and page_name %}{{url('frontdoor:feedback', session_id=session_id, page_name=page_name)}}{% else %}{{url('frontdoor:feedback')}}{% endif %}" tabindex="0">feedback</a> will help us to improve it.
         </span>
       </p>
     </div>


### PR DESCRIPTION
Removed role from the feedback banner as this was causing the screen reader to read 'link banner'. This is also consistent with the HTML on the live site. Added tab index but not a role since this would be redundant as the screen reader is already recognising the <a> tag as a link.