### PR TITLE
PC-373: Add session id to response headers

### DIFF
--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -76,7 +76,9 @@ def homepage_view(request):
     context = {
         "next_url": next_url,
     }
-    return render(request, template_name="frontdoor/homepage.html", context=context)
+    response = render(request, template_name="frontdoor/homepage.html", context=context)
+    response['x-vcap-request-id'] = session_id
+    return response
 
 
 def page_view(request, session_id, page_name):
@@ -87,8 +89,9 @@ def page_view(request, session_id, page_name):
     interface.api.session.save_answer(session_id, page_name, {"_page_name": page_name})
     prev_page_url, next_page_url = get_prev_next_urls(session_id, page_name)
     context = {"session_id": session_id, "page_name": page_name, "prev_url": prev_page_url}
-    return render(request, template_name=f"frontdoor/{page_name}.html", context=context)
-
+    response = render(request, template_name=f"frontdoor/{page_name}.html", context=context)
+    response['x-vcap-request-id'] = session_id
+    return response
 
 def change_page_view(request, session_id, page_name):
     assert page_name in page_map
@@ -150,7 +153,9 @@ class PageView(utils.MethodDispatcher):
             "next_url": next_page_url,
             **extra_context,
         }
-        return render(request, template_name=f"frontdoor/{page_name}.html", context=context)
+        response = render(request, template_name=f"frontdoor/{page_name}.html", context=context)
+        response['x-vcap-request-id'] = session_id
+        return response
 
     def get_prev_next_urls(self, session_id, page_name):
         return get_prev_next_urls(session_id, page_name)


### PR DESCRIPTION
Adds session ID to responses. (Fun fact the session ID is generated on the homepage even though you can't see it yet)