### PR TITLE
PC-393: Add role and tab index to NI gov link

### DIFF
--- a/help_to_heat/templates/frontdoor/northern-ireland.html
+++ b/help_to_heat/templates/frontdoor/northern-ireland.html
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">This service is not available for homes in Northern Ireland</h1>
-      <p class="govuk-body">The energy efficiency support available through this scheme is available to homes in England, Wales and Scotland. For advice on energy support measures in Northern Ireland visit the <a href="https://www.nidirect.gov.uk/information-and-services/environment-and-outdoors/energy-advice" class="govuk-link">NI Direct government services website</a>.
+      <p class="govuk-body">The energy efficiency support available through this scheme is available to homes in England, Wales and Scotland. For advice on energy support measures in Northern Ireland visit the <a href="https://www.nidirect.gov.uk/information-and-services/environment-and-outdoors/energy-advice" class="govuk-link" role="link" tabindex="0">NI Direct government services website</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Similar to the PR for PC-392, I've added a role and tabindex of 0, although the 'link' was already being read out by the screen reader. 

I wonder if I'm testing this correctly and if I should liaise with the reporter to reproduce exact steps? There's not much detail on the ticket.