### PR TITLE
PC-382 suppress missing auth logging

### DIFF
--- a/help_to_heat/auth.py
+++ b/help_to_heat/auth.py
@@ -15,7 +15,7 @@ class InvalidAuthError(Exception):
 def get_auth_from_header(request):
     auth_header = request.META.get("HTTP_AUTHORIZATION")
     if not auth_header:
-        raise InvalidAuthError("No auth header set")
+        return (None, None)
     if isinstance(auth_header, str):
         auth_header = auth_header.encode("utf-8")
     if b" " not in auth_header:


### PR DESCRIPTION
The existing handling for errors is to set `username` to `None`. Returning `(None, None)` means we won't log the error, and set both `username` and `password` to `None`, which also feels conceptually sound in response to not having auth headers at all.