### PR TITLE
PC-357 Security headers

### DIFF
--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -52,6 +52,7 @@ CORS_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "csp.middleware.CSPMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -63,6 +64,18 @@ MIDDLEWARE = [
 
 if BASIC_AUTH:
     MIDDLEWARE = ["help_to_heat.auth.basic_auth_middleware"] + MIDDLEWARE
+
+# Secure transport header timeout 5 minutes; we can up to something larger (like a year) when we're happy it's working.
+SECURE_HSTS_SECONDS = 300
+
+# Content Security Policy configurations
+CSP_DEFAULT_SRC = ("'self'")
+CSP_SCRIPT_SRC = ("'self'", "https://www.googletagmanager.com/")
+CSP_CONNECT_SRC = ("'self'")
+CSP_IMG_SRC = ("'self'")
+CSP_STYLE_SRC = ("'self'")
+CSP_BASE_URI = ("'self'")
+CSP_FORM_ACTION = ("'self'")
 
 # CSRF settings
 CSRF_COOKIE_HTTPONLY = True

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -12,6 +12,7 @@ defusedxml==0.7.1
 Django==3.2.19
 django-allauth==0.54.0
 django-cors-headers==4.0.0
+django-csp==3.7
 django-environ==0.10.0
 django-gov-notify==0.3.0
 django-use-email-as-username==1.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 boto3==1.26.86
 botocore==1.29.86
 debugpy==1.6.7
+django-csp==3.7
 jmespath==1.0.1
 localstack-client==1.39
 python-dateutil==2.8.2

--- a/requirements.lock
+++ b/requirements.lock
@@ -8,6 +8,7 @@ defusedxml==0.7.1
 Django==3.2.19
 django-allauth==0.54.0
 django-cors-headers==4.0.0
+django-csp==3.7
 django-environ==0.10.0
 django-gov-notify==0.3.0
 django-use-email-as-username==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 boto3==1.26.86
 botocore==1.29.86
 debugpy==1.6.7
+django-csp==3.7
 jmespath==1.0.1
 localstack-client==1.39
 python-dateutil==2.8.2


### PR DESCRIPTION
Added CSP middleware with explicit policies that match the pentest report suggestion, have verified both the presence of the header locally and that any other origins are blocked. From a cursory check (Ctrl-Shift-F `src=`) it looks like GTM is the only external source we use for anything.

Provided the Django setting to enable STS headers. Seems too painful to be worth testing locally, since we don't have valid SSL certs in local and Django tries to be clever about not setting them if a request didn't come in on HTTPS. It's possible it'll do the same when deployed, since HTTPS is terminated outside the application. If the header is missing, we'll either need the load balancer to set a header to indicate it *was* HTTPS, which we can tell Django to look for, or we don't bother with any of it in Django and get the load balancer to set the STS header on outgoing requests. Latter is probably more correct, but means extra work for BEIS Digital managing the header timeout, rather than us doing it.

Either way, we should set a very low STS timeout to start with, and ramp it up once we're happy everything's working.