### PR TITLE
PC-358 Cookie weaknesses

### DIFF
--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -66,6 +66,7 @@ if BASIC_AUTH:
 
 # CSRF settings
 CSRF_COOKIE_HTTPONLY = True
+CSRF_COOKIE_SECURE = True
 
 CORS_MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",


### PR DESCRIPTION
Testing on prod, the session cookie already appears to have both HTTPOnly and Secure flags.

CSRF has HTTPOnly but was missing Secure, so have added that.

Leaving GA cookies alone, since HTTPOnly will prevent it working entirely and we still want analytics for users on HTTP.