### PR TITLE
PC-NONE: Addresses failing if none found

### DIFF
--- a/help_to_heat/frontdoor/interface.py
+++ b/help_to_heat/frontdoor/interface.py
@@ -92,6 +92,8 @@ def get_addresses_from_api(postcode):
         return []
 
     total_results_number = json_response["header"]["totalresults"]
+    if total_results_number == 0:
+        return []
     api_results = json_response["results"]
     api_results_all = api_results
 


### PR DESCRIPTION
I don't know what's changed. I swear we previously didn't 500 if there were no addresses. I wonder if the OS API's changed?