### PR TITLE
PC-459: API Key Cycling

### DIFF
--- a/help_to_heat/frontdoor/interface.py
+++ b/help_to_heat/frontdoor/interface.py
@@ -86,7 +86,6 @@ class SuccessSchema(marshmallow.Schema):
 def get_addresses_from_api(postcode):
     max_results_number = 100
     offset = 0
-    key_to_use = 0
 
     json_response = OSApi(settings.OS_API_KEY).get_by_postcode(postcode, offset, max_results_number)
     if not json_response:

--- a/help_to_heat/frontdoor/os_api.py
+++ b/help_to_heat/frontdoor/os_api.py
@@ -1,8 +1,8 @@
+import ast
 import logging
 from http import HTTPStatus
 
 import requests
-import ast
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +33,8 @@ class OSApi:
                 status_code = e.response.status_code
                 if status_code == HTTPStatus.TOO_MANY_REQUESTS:
                     logger.error(f"The OS API usage limit has been hit for API key at index {index}.")
-                    if index == len(self.keys)-1:
-                        logger.error(f"The OS API usage limit has been hit for all API keys")
+                    if index == len(self.keys) - 1:
+                        logger.error("The OS API usage limit has been hit for all API keys")
                         raise ThrottledApiException
                     else:
                         continue


### PR DESCRIPTION
#  PC-459: Cycles through API keys when one is being rate-limited
- Adds logic to make the OS API class take an array of keys
- Cycles through said keys when they are being rate limited
- If all 5 are rate limited, displays the sorry screen
-----
## To-do:
- I feel like I should also make similar changes to the Mock OS API but right now every test is failing so it's hard to see what needs changing?
- Similarly I should write tests for this new behaviour, but currently this can't be done due to the above issue