### PR TITLE
PC-313: Restrict user inputs to 128 chars

### DIFF
--- a/help_to_heat/templates/macros.html
+++ b/help_to_heat/templates/macros.html
@@ -66,7 +66,7 @@
   </label>
   <input class="govuk-input" id="question-{{name}}" name="{{name}}" type="{{type}}" {% if errors.get(name) %}
     aria-describedby="question-{{name}}-error" {% endif %} autocomplete="{{autocomplete}}"
-    value="{{data.get(name, '')}}">
+    value="{{data.get(name, '')}}" maxlength="128">
 </div>
 {%- endmacro%}
 


### PR DESCRIPTION
Currently imposed a 128 char limit on all user inputs. If preferred, we can pass an optional argument to the constructor so this can be variable for each input. What do you think @JoshAdamPowell, @LadunOmideyiSoftwire?