### PR TITLE
PC-none: Fix reject cookies button

### DIFF
--- a/help_to_heat/templates/frontdoor/base.html
+++ b/help_to_heat/templates/frontdoor/base.html
@@ -51,7 +51,7 @@
                 <input type="hidden" name="prev" value="{{ request.path }}">
                 <div class="govuk-button-group">
                     <button type="submit" name="cookies" class="govuk-button" value="True">{{_("Accept cookies")}}</button>
-                    <button type="submit" name="cookies-f" class="govuk-button" value="False">{{_("Reject cookies")}}</button>
+                    <button type="submit" name="cookies" class="govuk-button" value="False">{{_("Reject cookies")}}</button>
                     <a class="govuk-link" href="/cookies">{{_("View cookies we use on this service")}}</a>
                 </div>
             </form>


### PR DESCRIPTION
Now I recall we tried to press the buttons while attempting to fix "multiple forms errors" in tests after adding the cookie banner . And the `cookies-f` was leftover from that attempt...