### PR TITLE
PC-NONE: Stop suppressing language toggle

### DIFF
--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -23,7 +23,7 @@ FROM_EMAIL = env.str("FROM_EMAIL", default="test@example.com")
 DEBUG = env.bool("DEBUG", default=False)
 
 SUPPRESS_COOKIE_BANNER = env.bool("SUPPRESS_COOKIE_BANNER", default=False)
-SUPPRESS_LANGUAGE_TOGGLE = env.bool("SUPPRESS_LANGUAGE_TOGGLE", default=True)
+SUPPRESS_LANGUAGE_TOGGLE = env.bool("SUPPRESS_LANGUAGE_TOGGLE", default=False)
 
 # TODO: Replace with fixed hosts once we know the domain
 ALLOWED_HOSTS = ["*"]


### PR DESCRIPTION
The last PR introduced a settings change that suppressed the language toggle permanently, this undoes that :)