### PR TITLE
PC-none: Add Welsh for email title

### DIFF
--- a/help_to_heat/portal/email_handler.py
+++ b/help_to_heat/portal/email_handler.py
@@ -125,9 +125,10 @@ def send_invite_email(user):
 def send_referral_confirmation_email(session_data, language_code):
     if language_code.startswith("cy"):
         data = EMAIL_MAPPING["referral-confirmation-cy"]
+        data["subject"] = "Cwblhau atgyfeiriad"
     else:
         data = EMAIL_MAPPING["referral-confirmation"]
-    data["subject"] = f"Referral to {session_data.get('supplier')} successful"
+        data["subject"] = f"Referral to {session_data.get('supplier')} successful"
     context = {"supplier_name": session_data.get("supplier")}
     return _send_normal_email(to_address=session_data.get("email"), context=context, **data)
 


### PR DESCRIPTION
Following comment under https://beisdigital.atlassian.net/browse/PC-471

Discussed with Ladun that we'll just use Welsh translation for "Referral completed" as that's the closest one...