### PR TITLE
PC-NONE: Update CSP setting to allow google analytics connection

### DIFF
--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -98,7 +98,7 @@ SECURE_HSTS_SECONDS = 300
 # Content Security Policy configurations
 CSP_DEFAULT_SRC = ("'self'",)
 CSP_SCRIPT_SRC = ("'self'", "https://www.googletagmanager.com/")
-CSP_CONNECT_SRC = ("'self'",)
+CSP_CONNECT_SRC = ("'self'", "*.google-analytics.com/")
 CSP_IMG_SRC = ("'self'",)
 CSP_STYLE_SRC = ("'self'",)
 CSP_BASE_URI = ("'self'",)


### PR DESCRIPTION
- Previously attempts to connect to Google Analytics (and thus send data) were blocked by the CSP security settings
- This change allows them to connect and send data