### PR TITLE
PC-none: Prevent user stylesheet overriding

### DIFF
--- a/help_to_heat/templates/frontdoor/base.html
+++ b/help_to_heat/templates/frontdoor/base.html
@@ -120,7 +120,7 @@
             <span aria-current="true">English</span>
             {% else %}
             <input name="language" type="hidden" value="en">
-            <button type="submit" lang="en" rel="alternate" class="govuk-link">
+            <button type="submit" lang="en" rel="alternate" class="govuk-link gbis-language-select__button-text">
               <span class="govuk-visually-hidden">Change the language to English</span>
               <span aria-hidden="true">English</span>
             </button>
@@ -131,7 +131,7 @@
             <span aria-current="true">Cymraeg</span>
             {% else %}
             <input name="language" type="hidden" value="cy">
-            <button type="submit" lang="cy" rel="alternate" class="govuk-link">
+            <button type="submit" lang="cy" rel="alternate" class="govuk-link gbis-language-select__button-text">
               <span class="govuk-visually-hidden">Newid yr iaith ir Gymraeg</span>
               <span aria-hidden="true">Cymraeg</span>
             </button>

--- a/static/main.css
+++ b/static/main.css
@@ -46,3 +46,7 @@
   border-right: none;
 }
 
+.gbis-language-select__button-text {
+    font-weight: normal;
+    color: #0b0c0c;
+}


### PR DESCRIPTION
Added a custom class to set colour and font weight specifically, so user stylesheet on ios won't override it with white text colour.

Before
![image](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/assets/104062694/9100b89f-be51-43bd-a17f-fb92f4f62fec)

After 
![image](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/assets/104062694/ef0cf0b4-f166-4d51-9f91-25dff7209fb8)
