### PR TITLE
PC-468: Change for attribute to suppress Wave accessibility error

### DIFF
--- a/help_to_heat/templates/allauth/account/login.html
+++ b/help_to_heat/templates/allauth/account/login.html
@@ -33,7 +33,7 @@
 
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input" id="id_remember" name="remember" type="checkbox">
-        <label class="govuk-label govuk-checkboxes__label" for="remember">
+        <label class="govuk-label govuk-checkboxes__label" for="id_remember">
           Remember me
         </label>
       </div>


### PR DESCRIPTION
Changed the for attribute on the label so that it matches the input's ID and Wave recognises the label as associated with a form control