### PR TITLE
PC-559: Add BG back

### DIFF
--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -77,7 +77,7 @@ missing_item_errors = {
 
 # to be updated when we get full list of excluded suppliers
 converted_suppliers = ["Bulb, now part of Octopus Energy", "Utility Warehouse"]
-unavailable_suppliers = ["British Gas"]
+unavailable_suppliers = []
 
 
 def unavailable_supplier_redirect(session_id):
@@ -624,7 +624,7 @@ class SupplierView(PageView):
         request_supplier = request_data.get("supplier")
         # to be updated when we get full list of excluded suppliers
         converted_suppliers = ["Bulb, now part of Octopus Energy", "Utility Warehouse"]
-        unavailable_suppliers = ["British Gas"]
+        unavailable_suppliers = []
         if request_supplier == "Bulb, now part of Octopus Energy":
             next_page_name = "bulb-warning-page"
         if request_supplier == "Utility Warehouse":

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -77,30 +77,6 @@ def test_flow_errors():
     assert page.has_text("Select where the property is located")
 
 
-def test_british_gas_unavailable():
-    client = utils.get_client()
-    page = client.get("/start")
-    assert page.status_code == 302
-    page = page.follow()
-
-    assert page.status_code == 200
-    session_id = page.path.split("/")[1]
-    assert uuid.UUID(session_id)
-
-    form = page.get_form()
-    form["country"] = "England"
-    page = form.submit().follow()
-
-    form = page.get_form()
-    form["supplier"] = "British Gas"
-    page = form.submit().follow()
-
-    assert page.has_text("British Gas are not taking referrals right now but they will be shortly")
-
-    page = page.click(contains="Back")
-    assert page.has_one("h1:contains('Select your home energy supplier from the list below')")
-
-
 @unittest.mock.patch("help_to_heat.frontdoor.interface.OSApi", MockOSApi)
 def _answer_house_questions(page, session_id, benefits_answer, epc_rating="D", supplier="Utilita"):
     """Answer main flow with set answers"""


### PR DESCRIPTION
Removed British Gas from the unavailable suppliers list, but haven't removed the logic in case we'll need it in the future. If that's unlikely, I can amend the PR to remove it entirely @LadunOmideyiSoftwire 