### PR TITLE
PC-519: CSV changes for service managers

### DIFF
--- a/help_to_heat/portal/download_views.py
+++ b/help_to_heat/portal/download_views.py
@@ -20,6 +20,7 @@ london_tz = tz.gettz("Europe/London")
 referral_column_headings = (
     "ECO4",
     "GBIS",
+    "country",
     "first_name",
     "last_name",
     "contact_number",
@@ -53,6 +54,8 @@ referral_column_headings = (
 referral_column_headings_no_pii = (
     "ECO4",
     "GBIS",
+    "country",
+    "postcode",
     "own_property",
     "benefits",
     "household_income",
@@ -236,7 +239,6 @@ def add_extra_row_data(referral, exclude_pii=False):
         "last_name",
         "email",
         "address",
-        "postcode",
         "contact_number",
     ]
 
@@ -264,7 +266,7 @@ def add_extra_row_data(referral, exclude_pii=False):
         **row,
         "ECO4": "ECO4" in eligibility and "Yes" or "No",
         "GBIS": "GBIS" in eligibility and "Yes" or "No",
-        "epc_rating": epc_rating and epc_rating != "Not found" or "",
+        "epc_rating": epc_rating and epc_rating or "",
         "epc_date": epc_date and epc_date or "",
         "submission_date": created_at.date(),
         "submission_time": created_at.time().strftime("%H:%M:%S"),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -32,7 +32,7 @@ def test_csv():
     text = csv_page.content.decode("utf-8")
     lines = text.splitlines()
     assert len(lines) == 2
-    assert len(lines[0].split(",")) == 30, len(lines[0].split(","))
+    assert len(lines[0].split(",")) == 31, len(lines[0].split(","))
 
     rows = list(csv.DictReader(lines))
     data = rows[0]


### PR DESCRIPTION
Additions to the CSV requested by DESNZ, in particular:

- Country
- Postcode
- EPC letter rating (in the case where we don't find a rating, I've kept the original logic intact, so we will still populate "", instead of "Not found" - hopefully this is fine

What the CSV looks like now locally for me:
![image](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/assets/104014956/6db67239-a5f5-4dff-ad56-8e5ecf2e93ad)
