### PR TITLE
PC-691: Removing So Energy from the user journey

### DIFF
--- a/help_to_heat/frontdoor/schemas.py
+++ b/help_to_heat/frontdoor/schemas.py
@@ -602,10 +602,6 @@ supplier_options = (
         "value": "Shell",
     },
     {
-        "label": "So Energy",
-        "value": "So Energy",
-    },
-    {
         "label": "Utilita",
         "value": "Utilita",
     },


### PR DESCRIPTION
removes so energy from the schema

the supplier page is generated from the schema and so so energy is removed from there
![image](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/assets/108681823/8c0e1a50-1da3-4845-aab6-ca37fc7431a7)


attempting to edit a radio button to so energy will no longer pass validation
![image](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/assets/108681823/04d63d5a-6815-44ae-829c-f160a92bc6ee)
![image](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/assets/108681823/f47e7148-d691-4916-8828-bf1036a55d3f)


though users with access to so energy can still view old records
![image](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/assets/108681823/dcf2c384-522b-408d-945a-525fcd8b080a)


since the portal tracks suppliers in a database user management is unaffected by this change
![image](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/assets/108681823/1cad13a3-54af-4fec-935b-8454ab92a0a8)