### PR TITLE
PC-741 Download all referrals from a custom date range

### DIFF
--- a/help_to_heat/portal/download_views.py
+++ b/help_to_heat/portal/download_views.py
@@ -206,9 +206,6 @@ def download_referrals_last_week_view(request):
 @require_http_methods(["GET"])
 @decorators.requires_service_manager
 def download_referrals_range_view(request):
-    # Weekly boundaries are Mondays at midnight (00:00)
-    # Referrals submitted between Monday 00:00:00 and Sunday 23:59:59.99... are included
-
     date_from = date(int(request.GET.get("from-year")), int(request.GET.get("from-month")), int(request.GET.get("from-day")))
     date_to = date(int(request.GET.get("to-year")), int(request.GET.get("to-month")), int(request.GET.get("to-day"))) + timedelta(days=1)
     file_name = f"Referrals {date_from.strftime('%d-%m-%Y')} to {date_to.strftime('%d-%m-%Y')}"

--- a/help_to_heat/portal/urls.py
+++ b/help_to_heat/portal/urls.py
@@ -75,6 +75,11 @@ portal_patterns = [
         download_views.download_referrals_last_week_view,
         name="referrals-last-week-download",
     ),
+    path(
+        "referrals-range-download/",
+        download_views.download_referrals_range_view,
+        name="referrals-range-download",
+    ),
     path("data-download/<uuid:download_id>/", download_views.download_csv_by_id_view, name="download-csv-by-id"),
     path("data-download-xlsx/", download_views.download_xlsx_view, name="data-download-xlsx"),
     path("data-download-xlsx/<uuid:download_id>/", download_views.download_xlsx_by_id_view, name="download-xlsx-by-id"),

--- a/help_to_heat/portal/views.py
+++ b/help_to_heat/portal/views.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import subprocess
-from datetime import date
 
 from django.contrib.auth.decorators import login_required
 from django.db import connection
@@ -97,7 +96,7 @@ def parse_date(year: str, month: str, day: str):
 
     def try_parse_date(year, month, day):
         try:
-            return date(year, month, day)
+            return datetime.date(year, month, day)
         except ValueError:
             return None
 
@@ -106,7 +105,7 @@ def parse_date(year: str, month: str, day: str):
     if check_date is None:
         return generate_error("%s must be a real date"), None
 
-    today = date.today()
+    today = datetime.date.today()
 
     if check_date > today:
         return generate_error("%s must be today or in the past"), None
@@ -170,7 +169,7 @@ def service_manager_homepage_view(request):
     suppliers = [supplier for supplier in models.Supplier.objects.all() if supplier.name not in suppliers_to_hide]
     suppliers.sort(key=lambda supplier: supplier.name)
     data = {
-        "suppliers": suppliers
+        "suppliers": suppliers,
     }
     return render(
         request,

--- a/help_to_heat/portal/views.py
+++ b/help_to_heat/portal/views.py
@@ -132,7 +132,7 @@ def parse_date_range(from_year, from_month, from_day, to_year, to_month, to_day)
         return errors, None, None
 
     if date_from > date_to:
-        errors["to"] = generate_error("%s must be the same as or after Date from")
+        errors["to"] = generate_error("%s must be the same as or after From")
         return errors, None, None
 
     return None, date_from, date_to

--- a/help_to_heat/portal/views.py
+++ b/help_to_heat/portal/views.py
@@ -76,17 +76,17 @@ def parse_date(year: str, month: str, day: str):
 
     year_error, year = parse_date_input(year, datetime.MINYEAR, datetime.MAXYEAR)
     if year_error:
-        error_messages.append(f"%s must include a valid year")
+        error_messages.append("%s must include a valid year")
         year_error = True
 
     month_error, month = parse_date_input(month, 1, 12)
     if month_error:
-        error_messages.append(f"%s must include a valid month")
+        error_messages.append("%s must include a valid month")
         month_error = True
 
     day_error, day = parse_date_input(day, 1, 31)
     if day_error:
-        error_messages.append(f"%s must include a valid day")
+        error_messages.append("%s must include a valid day")
         day_error = True
 
     if error_messages:

--- a/help_to_heat/portal/views.py
+++ b/help_to_heat/portal/views.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+from datetime import date
 
 from django.contrib.auth.decorators import login_required
 from django.db import connection
@@ -31,34 +32,106 @@ def unauthorised_view(request):
     return render(request, "portal/unauthorised.html", {}, status=403)
 
 
-@require_http_methods(["GET"])
+@require_http_methods(["GET", "POST"])
 @login_required(login_url="portal:unauthorised")
 def homepage_view(request):
     user = request.user
-    if user.is_service_manager:
-        return service_manager_homepage_view(request)
-    elif user.is_team_leader:
-        return team_leader_homepage_view(request)
-    elif user.is_team_member:
-        return team_member_homepage_view(request)
-    else:
-        return redirect("portal:unauthorised")
+    if request.method == "GET":
+        if user.is_service_manager:
+            return service_manager_homepage_view(request)
+        elif user.is_team_leader:
+            return team_leader_homepage_view(request)
+        elif user.is_team_member:
+            return team_member_homepage_view(request)
+    elif request.method == "POST":
+        if user.is_service_manager:
+            return service_manager_homepage_view(request)
+
+    return redirect("portal:unauthorised")
 
 
-@require_http_methods(["GET"])
+def parse_date(year: str, month: str, day: str):
+    if year == "":
+        return "year-required", "year", None
+    if month == "":
+        return "month-required", "month", None
+    if day == "":
+        return "day-required", "day", None
+
+    if not year.isdecimal():
+        return "year-integer", "year", None
+    if not month.isdecimal():
+        return "month-integer", "month", None
+    if not day.isdecimal():
+        return "day-integer", "day", None
+
+    year = int(year)
+    month = int(month)
+    day = int(day)
+
+    def try_parse_date(year, month, day):
+        try:
+            return date(year, month, day)
+        except ValueError:
+            return None
+
+    check_date = try_parse_date(year, month, day)
+
+    if check_date is None:
+        return "invalid", "all", None
+
+    today = date.today()
+
+    if check_date > today:
+        return "future", "all", None
+
+    return None, check_date
+
+
+@require_http_methods(["GET", "POST"])
 @decorators.requires_service_manager
 def service_manager_homepage_view(request):
+    errors = {}
+    if request.method == "POST":
+        date_from_error, date_from_error_location, date_from = parse_date(
+            request.POST.get("from-year", None),
+            request.POST.get("from-month", None),
+            request.POST.get("from-day", None)
+        )
+        date_to_error, date_to_error_location, date_to = parse_date(
+            request.POST.get("to-year", None),
+            request.POST.get("to-month", None),
+            request.POST.get("to-day", None)
+        )
+
+        if date_from_error:
+            errors["from"] = date_from_error
+            if date_from_error_location in ["all", "year"]:
+                errors["from-year"] = True
+            if date_from_error_location in ["all", "month"]:
+                errors["from-month"] = True
+            if date_from_error_location in ["all", "day"]:
+                errors["from-day"] = True
+        if date_to_error:
+            errors["to"] = date_to_error
+            if date_to_error_location in ["all", "year"]:
+                errors["to-year"] = True
+            if date_to_error_location in ["all", "month"]:
+                errors["to-month"] = True
+            if date_to_error_location in ["all", "day"]:
+                errors["to-day"] = True
+
     template = "portal/service-manager/homepage.html"
     suppliers_to_hide = ["Bulb, now part of Octopus Energy", "ESB"]
     suppliers = [supplier for supplier in models.Supplier.objects.all() if supplier.name not in suppliers_to_hide]
     suppliers.sort(key=lambda supplier: supplier.name)
     data = {
-        "suppliers": suppliers,
+        "suppliers": suppliers
     }
     return render(
         request,
         template_name=template,
-        context={"request": request, "data": data},
+        context={"request": request, "data": data, "errors": errors, "previous": request.POST},
     )
 
 

--- a/help_to_heat/templates/macros.html
+++ b/help_to_heat/templates/macros.html
@@ -129,3 +129,48 @@
   </div>
 </div>
 {%- endmacro%}
+
+{% macro date_input(field, label, errors) %}
+<div class="govuk-form-group govuk-grid-column-one-half {{ "govuk-form-group--error" if errors[field] else "" }}">
+  <fieldset class="govuk-fieldset" role="group">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      <h1 class="govuk-fieldset__heading">
+        {{ label }}
+      </h1>
+    </legend>
+    {% if errors[field] %}
+      {% for error_message in errors[field]["error_messages"] %}
+        <p id="passport-issued-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> {{ error_message % label }}
+        </p>
+      {% endfor %}
+    {% endif %}
+    <div class="govuk-date-input" id={{ field }}>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="{{ field }}-day">
+            Day
+          </label>
+          <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors.get(field, {})["day"] else "" }}" id="{{ field }}-day" name="{{ field }}-day" type="text" inputmode="numeric" value="{{ previous.get(field + "-day", "") }}">
+        </div>
+      </div>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="{{ field }}-month">
+            Month
+          </label>
+          <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors.get(field, {})["month"] else "" }}" id="{{ field }}-month" name="{{ field }}-month" type="text" inputmode="numeric" value="{{ previous.get(field + "-month", "") }}">
+        </div>
+      </div>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="{{ field }}-year">
+            Year
+          </label>
+          <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ "govuk-input--error" if errors.get(field, {})["year"] else "" }}" id="{{ field }}-year" name="{{ field }}-year" type="text" inputmode="numeric" value="{{ previous.get(field + "-year", "") }}">
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>
+{%- endmacro %}

--- a/help_to_heat/templates/portal/service-manager/supplier-list.html
+++ b/help_to_heat/templates/portal/service-manager/supplier-list.html
@@ -45,7 +45,8 @@
 <p class="govuk-body">Download referrals from the last week as an Excel spreadsheet</p>
 <a href="{{url('portal:referrals-last-week-download')}}" class="govuk-button">Download</a>
 
-<form method="GET" action="{{ url('portal:referrals-range-download') }}" novalidate rel="noopener">
+<form method="POST" novalidate>
+  {{csrf_input}}
   <h1 class="govuk-heading-l">Download referrals from date range</h1>
   <p class="govuk-body">Download referrals from a specific date range as an Excel spreadsheet.</p>
   
@@ -63,7 +64,7 @@
               <label class="govuk-label govuk-date-input__label" for="from-day">
                 Day
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="from-day" name="from-day" type="text" inputmode="numeric">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="from-day" name="from-day" type="text" inputmode="numeric" value="{{ previous.get("from-day", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -71,7 +72,7 @@
               <label class="govuk-label govuk-date-input__label" for="from-month">
                 Month
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="from-month" name="from-month" type="text" inputmode="numeric">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="from-month" name="from-month" type="text" inputmode="numeric" value="{{ previous.get("from-month", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -79,26 +80,31 @@
               <label class="govuk-label govuk-date-input__label" for="from-year">
                 Year
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="from-year" name="from-year" type="text" inputmode="numeric">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="from-year" name="from-year" type="text" inputmode="numeric" value="{{ previous.get("from-year", "") }}">
             </div>
           </div>
         </div>
       </fieldset>
     </div>
-    <div class="govuk-form-group govuk-grid-column-one-half">
+    <div class="govuk-form-group govuk-grid-column-one-half {{ "govuk-form-group--error" if errors["to"] else "" }}">
       <fieldset class="govuk-fieldset" role="group" aria-describedby="to-hint">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
           <h1 class="govuk-fieldset__heading">
             To
           </h1>
         </legend>
+        {% if errors["to"] %}
+          <p id="passport-issued-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> {{ errors["to"] }}
+          </p>
+        {% endif %} 
         <div class="govuk-date-input" id="to">
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <label class="govuk-label govuk-date-input__label" for="to-day">
                 Day
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="to-day" name="to-day" type="text" inputmode="numeric">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["to-day"] else "" }}" id="to-day" name="to-day" type="text" inputmode="numeric" value="{{ previous.get("to-day", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -106,7 +112,7 @@
               <label class="govuk-label govuk-date-input__label" for="to-month">
                 Month
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="to-month" name="to-month" type="text" inputmode="numeric">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["to-month"] else "" }}" id="to-month" name="to-month" type="text" inputmode="numeric" value="{{ previous.get("to-month", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -114,7 +120,7 @@
               <label class="govuk-label govuk-date-input__label" for="to-year">
                 Year
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="to-year" name="to-year" type="text" inputmode="numeric">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ "govuk-input--error" if errors["to-year"] else "" }}" id="to-year" name="to-year" type="text" inputmode="numeric" value="{{ previous.get("to-year", "") }}">
             </div>
           </div>
         </div>

--- a/help_to_heat/templates/portal/service-manager/supplier-list.html
+++ b/help_to_heat/templates/portal/service-manager/supplier-list.html
@@ -51,7 +51,7 @@
   <p class="govuk-body">Download referrals from a specific date range as an Excel spreadsheet.</p>
   
   <div class="govuk-grid-row">
-    <div class="govuk-form-group govuk-grid-column-one-half {{ "govuk-form-group--error" if errors["to"] else "" }}">
+    <div class="govuk-form-group govuk-grid-column-one-half {{ "govuk-form-group--error" if errors["from"] else "" }}">
       <fieldset class="govuk-fieldset" role="group" aria-describedby="from-hint">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
           <h1 class="govuk-fieldset__heading">
@@ -61,7 +61,7 @@
         {% if errors["from"] %}
           {% for error_message in errors["from"]["error_messages"] %}
             <p id="passport-issued-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span> {{ error_message }}
+              <span class="govuk-visually-hidden">Error:</span> {{ error_message % "Date from" }}
             </p>
           {% endfor %}
         {% endif %} 
@@ -71,7 +71,7 @@
               <label class="govuk-label govuk-date-input__label" for="from-day">
                 Day
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["from"]["day"] else "" }}" id="from-day" name="from-day" type="text" inputmode="numeric" value="{{ previous.get("from-day", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors.get("from", {})["day"] else "" }}" id="from-day" name="from-day" type="text" inputmode="numeric" value="{{ previous.get("from-day", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -79,7 +79,7 @@
               <label class="govuk-label govuk-date-input__label" for="from-month">
                 Month
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["from"]["month"] else "" }}" id="from-month" name="from-month" type="text" inputmode="numeric" value="{{ previous.get("from-month", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors.get("from", {})["month"] else "" }}" id="from-month" name="from-month" type="text" inputmode="numeric" value="{{ previous.get("from-month", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -87,7 +87,7 @@
               <label class="govuk-label govuk-date-input__label" for="from-year">
                 Year
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ "govuk-input--error" if errors["from"]["year"] else "" }}" id="from-year" name="from-year" type="text" inputmode="numeric" value="{{ previous.get("from-year", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ "govuk-input--error" if errors.get("from", {})["year"] else "" }}" id="from-year" name="from-year" type="text" inputmode="numeric" value="{{ previous.get("from-year", "") }}">
             </div>
           </div>
         </div>
@@ -103,7 +103,7 @@
         {% if errors["to"] %}
           {% for error_message in errors["to"]["error_messages"] %}
             <p id="passport-issued-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span> {{ error_message }}
+              <span class="govuk-visually-hidden">Error:</span> {{ error_message % "Date to" }}
             </p>
           {% endfor %}
         {% endif %} 
@@ -113,7 +113,7 @@
               <label class="govuk-label govuk-date-input__label" for="to-day">
                 Day
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["to"]["day"] else "" }}" id="to-day" name="to-day" type="text" inputmode="numeric" value="{{ previous.get("to-day", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors.get("to", {})["day"] else "" }}" id="to-day" name="to-day" type="text" inputmode="numeric" value="{{ previous.get("to-day", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -121,7 +121,7 @@
               <label class="govuk-label govuk-date-input__label" for="to-month">
                 Month
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["to"]["month"] else "" }}" id="to-month" name="to-month" type="text" inputmode="numeric" value="{{ previous.get("to-month", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors.get("to", {})["month"] else "" }}" id="to-month" name="to-month" type="text" inputmode="numeric" value="{{ previous.get("to-month", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -129,7 +129,7 @@
               <label class="govuk-label govuk-date-input__label" for="to-year">
                 Year
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ "govuk-input--error" if errors["to"]["year"] else "" }}" id="to-year" name="to-year" type="text" inputmode="numeric" value="{{ previous.get("to-year", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ "govuk-input--error" if errors.get("to", {})["year"] else "" }}" id="to-year" name="to-year" type="text" inputmode="numeric" value="{{ previous.get("to-year", "") }}">
             </div>
           </div>
         </div>

--- a/help_to_heat/templates/portal/service-manager/supplier-list.html
+++ b/help_to_heat/templates/portal/service-manager/supplier-list.html
@@ -42,5 +42,85 @@
 <a href="{{url('portal:feedback-download')}}" class="govuk-button">Download</a>
 
 <h1 class="govuk-heading-l">Download referrals from the last week</h1>
-<p class="govuk-body">Download referrals from the last week in xlsx format.</p>
+<p class="govuk-body">Download referrals from the last week as an Excel spreadsheet</p>
 <a href="{{url('portal:referrals-last-week-download')}}" class="govuk-button">Download</a>
+
+<form method="GET" action="{{ url('portal:referrals-range-download') }}" novalidate rel="noopener">
+  <h1 class="govuk-heading-l">Download referrals from date range</h1>
+  <p class="govuk-body">Download referrals from a specific date range as an Excel spreadsheet.</p>
+  
+  <div class="govuk-grid-row">
+    <div class="govuk-form-group govuk-grid-column-one-half">
+      <fieldset class="govuk-fieldset" role="group" aria-describedby="from-hint">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <h1 class="govuk-fieldset__heading">
+            From
+          </h1>
+        </legend>
+        <div class="govuk-date-input" id="from">
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-date-input__label" for="from-day">
+                Day
+              </label>
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="from-day" name="from-day" type="text" inputmode="numeric">
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-date-input__label" for="from-month">
+                Month
+              </label>
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="from-month" name="from-month" type="text" inputmode="numeric">
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-date-input__label" for="from-year">
+                Year
+              </label>
+              <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="from-year" name="from-year" type="text" inputmode="numeric">
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div class="govuk-form-group govuk-grid-column-one-half">
+      <fieldset class="govuk-fieldset" role="group" aria-describedby="to-hint">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <h1 class="govuk-fieldset__heading">
+            To
+          </h1>
+        </legend>
+        <div class="govuk-date-input" id="to">
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-date-input__label" for="to-day">
+                Day
+              </label>
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="to-day" name="to-day" type="text" inputmode="numeric">
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-date-input__label" for="to-month">
+                Month
+              </label>
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="to-month" name="to-month" type="text" inputmode="numeric">
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-date-input__label" for="to-year">
+                Year
+              </label>
+              <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="to-year" name="to-year" type="text" inputmode="numeric">
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+  
+  <button class="govuk-button" data-module="govuk-button" type="submit">Download</button>
+</form>

--- a/help_to_heat/templates/portal/service-manager/supplier-list.html
+++ b/help_to_heat/templates/portal/service-manager/supplier-list.html
@@ -1,3 +1,5 @@
+{% import "macros.html" as macros with context %}
+
 <h1 class="govuk-heading-l">Add, view and manage energy suppliers</h1>
 <p class="govuk-body">Add, view and manage energy suppliers who can access and download customer leads.</p>
 <a class="govuk-button" href="{{url('portal:add-supplier')}}">Add a new energy supplier</a>
@@ -42,7 +44,7 @@
 <a href="{{url('portal:feedback-download')}}" class="govuk-button">Download</a>
 
 <h1 class="govuk-heading-l">Download referrals from the last week</h1>
-<p class="govuk-body">Download referrals from the last week as an Excel spreadsheet</p>
+<p class="govuk-body">Download referrals from the last week as an Excel spreadsheet.</p>
 <a href="{{url('portal:referrals-last-week-download')}}" class="govuk-button">Download</a>
 
 <form method="POST" novalidate>
@@ -51,90 +53,8 @@
   <p class="govuk-body">Download referrals from a specific date range as an Excel spreadsheet.</p>
   
   <div class="govuk-grid-row">
-    <div class="govuk-form-group govuk-grid-column-one-half {{ "govuk-form-group--error" if errors["from"] else "" }}">
-      <fieldset class="govuk-fieldset" role="group" aria-describedby="from-hint">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-          <h1 class="govuk-fieldset__heading">
-            From
-          </h1>
-        </legend>
-        {% if errors["from"] %}
-          {% for error_message in errors["from"]["error_messages"] %}
-            <p id="passport-issued-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span> {{ error_message % "Date from" }}
-            </p>
-          {% endfor %}
-        {% endif %} 
-        <div class="govuk-date-input" id="from">
-          <div class="govuk-date-input__item">
-            <div class="govuk-form-group">
-              <label class="govuk-label govuk-date-input__label" for="from-day">
-                Day
-              </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors.get("from", {})["day"] else "" }}" id="from-day" name="from-day" type="text" inputmode="numeric" value="{{ previous.get("from-day", "") }}">
-            </div>
-          </div>
-          <div class="govuk-date-input__item">
-            <div class="govuk-form-group">
-              <label class="govuk-label govuk-date-input__label" for="from-month">
-                Month
-              </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors.get("from", {})["month"] else "" }}" id="from-month" name="from-month" type="text" inputmode="numeric" value="{{ previous.get("from-month", "") }}">
-            </div>
-          </div>
-          <div class="govuk-date-input__item">
-            <div class="govuk-form-group">
-              <label class="govuk-label govuk-date-input__label" for="from-year">
-                Year
-              </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ "govuk-input--error" if errors.get("from", {})["year"] else "" }}" id="from-year" name="from-year" type="text" inputmode="numeric" value="{{ previous.get("from-year", "") }}">
-            </div>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-    <div class="govuk-form-group govuk-grid-column-one-half {{ "govuk-form-group--error" if errors["to"] else "" }}">
-      <fieldset class="govuk-fieldset" role="group" aria-describedby="to-hint">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-          <h1 class="govuk-fieldset__heading">
-            To
-          </h1>
-        </legend>
-        {% if errors["to"] %}
-          {% for error_message in errors["to"]["error_messages"] %}
-            <p id="passport-issued-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span> {{ error_message % "Date to" }}
-            </p>
-          {% endfor %}
-        {% endif %} 
-        <div class="govuk-date-input" id="to">
-          <div class="govuk-date-input__item">
-            <div class="govuk-form-group">
-              <label class="govuk-label govuk-date-input__label" for="to-day">
-                Day
-              </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors.get("to", {})["day"] else "" }}" id="to-day" name="to-day" type="text" inputmode="numeric" value="{{ previous.get("to-day", "") }}">
-            </div>
-          </div>
-          <div class="govuk-date-input__item">
-            <div class="govuk-form-group">
-              <label class="govuk-label govuk-date-input__label" for="to-month">
-                Month
-              </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors.get("to", {})["month"] else "" }}" id="to-month" name="to-month" type="text" inputmode="numeric" value="{{ previous.get("to-month", "") }}">
-            </div>
-          </div>
-          <div class="govuk-date-input__item">
-            <div class="govuk-form-group">
-              <label class="govuk-label govuk-date-input__label" for="to-year">
-                Year
-              </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ "govuk-input--error" if errors.get("to", {})["year"] else "" }}" id="to-year" name="to-year" type="text" inputmode="numeric" value="{{ previous.get("to-year", "") }}">
-            </div>
-          </div>
-        </div>
-      </fieldset>
-    </div>
+    {{macros.date_input("from", "From", errors)}}
+    {{macros.date_input("to", "To", errors)}}
   </div>
   
   <button class="govuk-button" data-module="govuk-button" type="submit">Download</button>

--- a/help_to_heat/templates/portal/service-manager/supplier-list.html
+++ b/help_to_heat/templates/portal/service-manager/supplier-list.html
@@ -51,20 +51,27 @@
   <p class="govuk-body">Download referrals from a specific date range as an Excel spreadsheet.</p>
   
   <div class="govuk-grid-row">
-    <div class="govuk-form-group govuk-grid-column-one-half">
+    <div class="govuk-form-group govuk-grid-column-one-half {{ "govuk-form-group--error" if errors["to"] else "" }}">
       <fieldset class="govuk-fieldset" role="group" aria-describedby="from-hint">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
           <h1 class="govuk-fieldset__heading">
             From
           </h1>
         </legend>
+        {% if errors["from"] %}
+          {% for error_message in errors["from"]["error_messages"] %}
+            <p id="passport-issued-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> {{ error_message }}
+            </p>
+          {% endfor %}
+        {% endif %} 
         <div class="govuk-date-input" id="from">
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <label class="govuk-label govuk-date-input__label" for="from-day">
                 Day
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="from-day" name="from-day" type="text" inputmode="numeric" value="{{ previous.get("from-day", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["from"]["day"] else "" }}" id="from-day" name="from-day" type="text" inputmode="numeric" value="{{ previous.get("from-day", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -72,7 +79,7 @@
               <label class="govuk-label govuk-date-input__label" for="from-month">
                 Month
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="from-month" name="from-month" type="text" inputmode="numeric" value="{{ previous.get("from-month", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["from"]["month"] else "" }}" id="from-month" name="from-month" type="text" inputmode="numeric" value="{{ previous.get("from-month", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -80,7 +87,7 @@
               <label class="govuk-label govuk-date-input__label" for="from-year">
                 Year
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="from-year" name="from-year" type="text" inputmode="numeric" value="{{ previous.get("from-year", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ "govuk-input--error" if errors["from"]["year"] else "" }}" id="from-year" name="from-year" type="text" inputmode="numeric" value="{{ previous.get("from-year", "") }}">
             </div>
           </div>
         </div>
@@ -94,9 +101,11 @@
           </h1>
         </legend>
         {% if errors["to"] %}
-          <p id="passport-issued-error" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> {{ errors["to"] }}
-          </p>
+          {% for error_message in errors["to"]["error_messages"] %}
+            <p id="passport-issued-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> {{ error_message }}
+            </p>
+          {% endfor %}
         {% endif %} 
         <div class="govuk-date-input" id="to">
           <div class="govuk-date-input__item">
@@ -104,7 +113,7 @@
               <label class="govuk-label govuk-date-input__label" for="to-day">
                 Day
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["to-day"] else "" }}" id="to-day" name="to-day" type="text" inputmode="numeric" value="{{ previous.get("to-day", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["to"]["day"] else "" }}" id="to-day" name="to-day" type="text" inputmode="numeric" value="{{ previous.get("to-day", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -112,7 +121,7 @@
               <label class="govuk-label govuk-date-input__label" for="to-month">
                 Month
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["to-month"] else "" }}" id="to-month" name="to-month" type="text" inputmode="numeric" value="{{ previous.get("to-month", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ "govuk-input--error" if errors["to"]["month"] else "" }}" id="to-month" name="to-month" type="text" inputmode="numeric" value="{{ previous.get("to-month", "") }}">
             </div>
           </div>
           <div class="govuk-date-input__item">
@@ -120,7 +129,7 @@
               <label class="govuk-label govuk-date-input__label" for="to-year">
                 Year
               </label>
-              <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ "govuk-input--error" if errors["to-year"] else "" }}" id="to-year" name="to-year" type="text" inputmode="numeric" value="{{ previous.get("to-year", "") }}">
+              <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ "govuk-input--error" if errors["to"]["year"] else "" }}" id="to-year" name="to-year" type="text" inputmode="numeric" value="{{ previous.get("to-year", "") }}">
             </div>
           </div>
         </div>


### PR DESCRIPTION
closes PC-741

adds functionality to export data across a range

contains a new download_view endpoint for downloading a range

validation is done by the portal page to simplify error logic

the logic doesn't follow gov uk guidance exactly (a error precedence rule should be enforced meaning the three fields can't just be checked in series), for now this is omitted & all errors are displayed