### PR TITLE
PC-NONE: Add pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+git stash -kqu
+
+if ! cmp -s "./envs/web" "./envs/web.template"; then
+    printf 'envs/web must match envs/web.template - check you are not trying to commit any API keys!\n'
+    git stash pop -q
+    exit 1
+fi
+
+git stash pop -q

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Formerly known as "Help to Heat".
     git config --local core.hooksPath .githooks
     cp envs/web.template envs/web
     ```
-3. Populate the OS API key into the OS_API_KEY variable. The key can be found in Keeper. Please only use a single value (i.e. `["my_key_here"]`), rather than all of the keys that are stored in Keeper, in order to avoid needing to rotate all of the keys if your local environment is accidentally leaked.
+2. Populate the OS API key into the OS_API_KEY variable. The key can be found in Keeper. Please only use a single value (i.e. `["my_key_here"]`), rather than all of the keys that are stored in Keeper, in order to avoid needing to rotate all of the keys if your local environment is accidentally leaked.
 
 ## Using Docker
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ Formerly known as "Help to Heat".
 
 ## Initial Setup
 
-1. From the project root, run `cp envs/web.template envs/web`
-2. Populate the OS API key into the OS_API_KEY variable. The key can be found in Keeper. Please only use a single value (i.e. `["my_key_here"]`), rather than all of the keys that are stored in Keeper, in order to avoid needing to rotate all of the keys if your local environment is accidentally leaked.
+1. From the project root, run:
+    ```
+    git config --local core.hooksPath .githooks
+    cp envs/web.template envs/web
+    ```
+3. Populate the OS API key into the OS_API_KEY variable. The key can be found in Keeper. Please only use a single value (i.e. `["my_key_here"]`), rather than all of the keys that are stored in Keeper, in order to avoid needing to rotate all of the keys if your local environment is accidentally leaked.
 
 ## Using Docker
 


### PR DESCRIPTION
In the interests of preventing accidental commits of API keys. Simple hook that compares `web` and `web.template` in staged changes and rejects the commit if they don't match.

As discussed, longer-term goal is still getting the file gitignored.