### PR TITLE
PC 898 partial fix specific backlinks

### DIFF
--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -644,7 +644,6 @@ class PropertyTypeView(PageView):
             return super().get_prev_next_urls(session_id, page_name)
 
 
-
 @register_page("property-subtype")
 class PropertySubtypeView(PageView):
     def get_context(self, request, session_id, *args, **kwargs):

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -634,7 +634,6 @@ class PropertyTypeView(PageView):
         session_data = interface.api.session.get_session(session_id)
         own_property = session_data.get("own_property")
         country = session_data.get("country")
-        epc = session_data.get("epc")
         epc_rating = session_data.get("epc_rating", "Not found")
 
         if own_property == "No, I am a social housing tenant" and (country == "Scotland" or epc_rating == "Not found"):

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -595,6 +595,19 @@ class BenefitsView(PageView):
             return redirect("frontdoor:page", session_id=session_id, page_name="property-type")
         return super().handle_post(request, session_id, page_name, data, is_change_page)
 
+    def get_prev_next_urls(self, session_id, page_name):
+        session_data = interface.api.session.get_session(session_id)
+        park_home = session_data.get("park_home")
+        country = session_data.get("country")
+        epc_rating = session_data.get("epc_rating", "Not found")
+
+        if park_home == "Yes" and (country == "Scotland" or epc_rating == "Not found"):
+            _, next_page_url = get_prev_next_urls(session_id, page_name)
+            prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="address"))
+            return prev_page_url, next_page_url
+        else:
+            return super().get_prev_next_urls(session_id, page_name)
+
 
 @register_page("household-income")
 class HouseholdIncomeView(PageView):
@@ -616,6 +629,21 @@ class HouseholdIncomeView(PageView):
 class PropertyTypeView(PageView):
     def get_context(self, *args, **kwargs):
         return {"property_type_options": schemas.property_type_options_map}
+
+    def get_prev_next_urls(self, session_id, page_name):
+        session_data = interface.api.session.get_session(session_id)
+        own_property = session_data.get("own_property")
+        country = session_data.get("country")
+        epc = session_data.get("epc")
+        epc_rating = session_data.get("epc_rating", "Not found")
+
+        if own_property == "No, I am a social housing tenant" and (country == "Scotland" or epc_rating == "Not found"):
+            _, next_page_url = get_prev_next_urls(session_id, page_name)
+            prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="address"))
+            return prev_page_url, next_page_url
+        else:
+            return super().get_prev_next_urls(session_id, page_name)
+
 
 
 @register_page("property-subtype")

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -598,10 +598,9 @@ class BenefitsView(PageView):
     def get_prev_next_urls(self, session_id, page_name):
         session_data = interface.api.session.get_session(session_id)
         park_home = session_data.get("park_home")
-        country = session_data.get("country")
         epc_rating = session_data.get("epc_rating", "Not found")
 
-        if park_home == "Yes" and (country == "Scotland" or epc_rating == "Not found"):
+        if park_home == "Yes" and epc_rating == "Not found":
             _, next_page_url = get_prev_next_urls(session_id, page_name)
             prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="address"))
             return prev_page_url, next_page_url
@@ -633,10 +632,9 @@ class PropertyTypeView(PageView):
     def get_prev_next_urls(self, session_id, page_name):
         session_data = interface.api.session.get_session(session_id)
         own_property = session_data.get("own_property")
-        country = session_data.get("country")
         epc_rating = session_data.get("epc_rating", "Not found")
 
-        if own_property == "No, I am a social housing tenant" and (country == "Scotland" or epc_rating == "Not found"):
+        if own_property == "No, I am a social housing tenant" and epc_rating == "Not found":
             _, next_page_url = get_prev_next_urls(session_id, page_name)
             prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="address"))
             return prev_page_url, next_page_url

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -305,7 +305,7 @@ def test_back_button():
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockNotFoundEPCApi)
 @unittest.mock.patch("help_to_heat.frontdoor.interface.OSApi", MockOSApi)
 @utils.mock_os_api
-def test_benefits_back_button_with_park_home_and_no_epc():
+def test_benefits_back_button_with_park_home_and_no_epc_should_return_to_address_page():
     client = utils.get_client()
     page = client.get("/start")
     assert page.status_code == 302
@@ -362,7 +362,7 @@ def test_benefits_back_button_with_park_home_and_no_epc():
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.OSApi", MockOSApi)
 @utils.mock_os_api
-def test_benefits_back_button_with_park_home_and_scotland():
+def test_benefits_back_button_with_park_home_and_scotland_should_return_to_address_page():
     client = utils.get_client()
     page = client.get("/start")
     assert page.status_code == 302
@@ -420,7 +420,7 @@ def test_benefits_back_button_with_park_home_and_scotland():
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockNotFoundEPCApi)
 @unittest.mock.patch("help_to_heat.frontdoor.interface.OSApi", MockOSApi)
 @utils.mock_os_api
-def test_property_type_back_button_with_social_housing_and_no_epc():
+def test_property_type_back_button_with_social_housing_and_no_epc_should_return_to_address_page():
     client = utils.get_client()
     page = client.get("/start")
     assert page.status_code == 302
@@ -471,7 +471,7 @@ def test_property_type_back_button_with_social_housing_and_no_epc():
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.OSApi", MockOSApi)
 @utils.mock_os_api
-def test_property_type_back_button_with_social_housing_and_scotland():
+def test_property_type_back_button_with_social_housing_and_scotland_should_return_to_address_page():
     client = utils.get_client()
     page = client.get("/start")
     assert page.status_code == 302

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -302,6 +302,224 @@ def test_back_button():
     assert form["country"] == "England"
 
 
+@unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockNotFoundEPCApi)
+@unittest.mock.patch("help_to_heat.frontdoor.interface.OSApi", MockOSApi)
+@utils.mock_os_api
+def test_benefits_back_button_with_park_home_and_no_epc():
+    client = utils.get_client()
+    page = client.get("/start")
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.status_code == 200
+    session_id = page.path.split("/")[1]
+    assert uuid.UUID(session_id)
+    _check_page = _make_check_page(session_id)
+
+    form = page.get_form()
+    form["country"] = "England"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    form["supplier"] = "Utilita"
+    page = form.submit().follow()
+
+    assert page.has_text("Do you own the property?")
+    page = _check_page(page, "own-property", "own_property", "Yes, I own my property and live in it")
+
+    assert page.has_text("Do you live in a park home?")
+    page = _check_page(page, "park-home", "park_home", "Yes")
+
+    assert page.has_text("Is the park home your main residence?")
+    page = _check_page(page, "park-home-main-residence", "park_home_main_residence", "Yes")
+
+    form = page.get_form()
+    form["building_name_or_number"] = "10"
+    form["postcode"] = "SW1A 2AA"
+    page = form.submit().follow()
+
+    data = interface.api.session.get_answer(session_id, page_name="address")
+    assert data["building_name_or_number"] == "10"
+    assert data["postcode"] == "SW1A 2AA"
+
+    form = page.get_form()
+    form["uprn"] = "100023336956"
+    page = form.submit().follow()
+
+    data = interface.api.session.get_answer(session_id, page_name="address-select")
+    assert data["uprn"] == "100023336956"
+    assert data["address"] == "10, DOWNING STREET, LONDON, CITY OF WESTMINSTER, SW1A 2AA"
+
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.has_one("h1:contains('Is anyone in your household receiving any of the following benefits?')")
+
+    page = page.click(contains="Back")
+
+    assert page.has_one('h1:contains("What is the property\'s address?")')
+
+
+@unittest.mock.patch("help_to_heat.frontdoor.interface.OSApi", MockOSApi)
+@utils.mock_os_api
+def test_benefits_back_button_with_park_home_and_scotland():
+    client = utils.get_client()
+    page = client.get("/start")
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.status_code == 200
+    session_id = page.path.split("/")[1]
+    assert uuid.UUID(session_id)
+    _check_page = _make_check_page(session_id)
+
+    form = page.get_form()
+    form["country"] = "Scotland"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    form["supplier"] = "Utilita"
+    page = form.submit().follow()
+
+    assert page.has_text("Do you own the property?")
+    page = _check_page(page, "own-property", "own_property", "Yes, I own my property and live in it")
+
+    assert page.has_text("Do you live in a park home?")
+    page = _check_page(page, "park-home", "park_home", "Yes")
+
+    assert page.has_text("Is the park home your main residence?")
+    page = _check_page(page, "park-home-main-residence", "park_home_main_residence", "Yes")
+
+    form = page.get_form()
+    form["building_name_or_number"] = "10"
+    form["postcode"] = "SW1A 2AA"
+    page = form.submit().follow()
+
+    data = interface.api.session.get_answer(session_id, page_name="address")
+    assert data["building_name_or_number"] == "10"
+    assert data["postcode"] == "SW1A 2AA"
+
+    form = page.get_form()
+    form["uprn"] = "100023336956"
+    page = form.submit().follow()
+
+    data = interface.api.session.get_answer(session_id, page_name="address-select")
+    assert data["uprn"] == "100023336956"
+    assert data["address"] == "10, DOWNING STREET, LONDON, CITY OF WESTMINSTER, SW1A 2AA"
+
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.has_one("h1:contains('Is anyone in your household receiving any of the following benefits?')")
+
+    page = page.click(contains="Back")
+
+    assert page.has_one('h1:contains("What is the property\'s address?")')
+
+
+@unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockNotFoundEPCApi)
+@unittest.mock.patch("help_to_heat.frontdoor.interface.OSApi", MockOSApi)
+@utils.mock_os_api
+def test_property_type_back_button_with_social_housing_and_no_epc():
+    client = utils.get_client()
+    page = client.get("/start")
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.status_code == 200
+    session_id = page.path.split("/")[1]
+    assert uuid.UUID(session_id)
+    _check_page = _make_check_page(session_id)
+
+    form = page.get_form()
+    form["country"] = "England"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    form["supplier"] = "Utilita"
+    page = form.submit().follow()
+
+    assert page.has_text("Do you own the property?")
+    page = _check_page(page, "own-property", "own_property", "No, I am a social housing tenant")
+
+    form = page.get_form()
+    form["building_name_or_number"] = "10"
+    form["postcode"] = "SW1A 2AA"
+    page = form.submit().follow()
+
+    data = interface.api.session.get_answer(session_id, page_name="address")
+    assert data["building_name_or_number"] == "10"
+    assert data["postcode"] == "SW1A 2AA"
+
+    form = page.get_form()
+    form["uprn"] = "100023336956"
+    page = form.submit().follow()
+
+    data = interface.api.session.get_answer(session_id, page_name="address-select")
+    assert data["uprn"] == "100023336956"
+    assert data["address"] == "10, DOWNING STREET, LONDON, CITY OF WESTMINSTER, SW1A 2AA"
+
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.has_one("h1:contains('What kind of property do you have?')")
+
+    page = page.click(contains="Back")
+
+    assert page.has_one('h1:contains("What is the property\'s address?")')
+
+
+@unittest.mock.patch("help_to_heat.frontdoor.interface.OSApi", MockOSApi)
+@utils.mock_os_api
+def test_property_type_back_button_with_social_housing_and_scotland():
+    client = utils.get_client()
+    page = client.get("/start")
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.status_code == 200
+    session_id = page.path.split("/")[1]
+    assert uuid.UUID(session_id)
+    _check_page = _make_check_page(session_id)
+
+    form = page.get_form()
+    form["country"] = "Scotland"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    form["supplier"] = "Utilita"
+    page = form.submit().follow()
+
+    assert page.has_text("Do you own the property?")
+    page = _check_page(page, "own-property", "own_property", "No, I am a social housing tenant")
+
+    form = page.get_form()
+    form["building_name_or_number"] = "10"
+    form["postcode"] = "SW1A 2AA"
+    page = form.submit().follow()
+
+    data = interface.api.session.get_answer(session_id, page_name="address")
+    assert data["building_name_or_number"] == "10"
+    assert data["postcode"] == "SW1A 2AA"
+
+    form = page.get_form()
+    form["uprn"] = "100023336956"
+    page = form.submit().follow()
+
+    data = interface.api.session.get_answer(session_id, page_name="address-select")
+    assert data["uprn"] == "100023336956"
+    assert data["address"] == "10, DOWNING STREET, LONDON, CITY OF WESTMINSTER, SW1A 2AA"
+
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.has_one("h1:contains('What kind of property do you have?')")
+
+    page = page.click(contains="Back")
+
+    assert page.has_one('h1:contains("What is the property\'s address?")')
+
+
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApiWithEPCC)
 def test_no_benefits_flow():
     client = utils.get_client()


### PR DESCRIPTION
Added specific backlink cases to make the backlink on the following pages in the following scenarios route the user back to the /address page

From the benefits page when the following two conditions are fulfilled:
- The user selects that they have a Park Home
- There is no EPC found for their Park Home, or they've selected that they live in Scotland

From the property type page when the following two conditions are fulfilled:
- The user selects that they live in Social Housing
- There is no EPC found for their home, or they've selected that they live in Scotland
