### PR TITLE
PC-900 Fix broken backlinks for Loft insulation

### DIFF
--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -737,6 +737,18 @@ class SummaryView(PageView):
             return supplier_redirect
         return super().handle_post(request, session_id, page_name, data, is_change_page)
 
+    def get_prev_next_urls(self, session_id, page_name):
+        session_data = interface.api.session.get_session(session_id)
+        loft = session_data.get("loft")
+
+        # if the user answered this, they went down the loft insulation route
+        if loft == "Yes, I have a loft that has not been converted into a room":
+            _, next_page_url = get_prev_next_urls(session_id, page_name)
+            prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="loft-insulation"))
+            return prev_page_url, next_page_url
+        else:
+            return super().get_prev_next_urls(session_id, page_name)
+
 
 @register_page("schemes")
 class SchemesView(PageView):

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -1,6 +1,8 @@
 import unittest
 import uuid
 
+import pytest
+
 from help_to_heat.frontdoor import interface
 from help_to_heat.frontdoor.mock_epc_api import (
     MockEPCApi,
@@ -1047,3 +1049,88 @@ def test_shell_redirects_to_warning():
     page = _check_page(page, "supplier", "supplier", "Shell")
 
     assert page.has_one("h1:contains('Your referral will be sent to Octopus Energy')")
+
+
+@unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApi)
+@pytest.mark.parametrize("has_loft_insulation", [True, False])
+def test_on_check_page_back_button_goes_to_correct_location(has_loft_insulation):
+    client = utils.get_client()
+    page = client.get("/start")
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.status_code == 200
+    session_id = page.path.split("/")[1]
+    assert uuid.UUID(session_id)
+    _check_page = _make_check_page(session_id)
+
+    form = page.get_form()
+    form["country"] = "England"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    form["supplier"] = "Utilita"
+    page = form.submit().follow()
+
+    assert page.has_text("Do you own the property?")
+    page = _check_page(page, "own-property", "own_property", "Yes, I own my property and live in it")
+
+    assert page.has_text("Do you live in a park home")
+    page = _check_page(page, "park-home", "park_home", "No")
+
+    form = page.get_form()
+    form["building_name_or_number"] = "22"
+    form["postcode"] = "FL23 4JA"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    form["rrn"] = "2222-2222-2222-2222-2222"
+    page = form.submit().follow()
+
+    data = interface.api.session.get_answer(session_id, page_name="epc-select")
+    assert data["rrn"] == "2222-2222-2222-2222-2222"
+    assert data["address"] == "22 Acacia Avenue, Upper Wellgood, Fulchester, FL23 4JA"
+
+    assert page.has_one("h1:contains('What is the council tax band of your property?')")
+    page = _check_page(page, "council-tax-band", "council_tax_band", "B")
+
+    assert page.has_one("h1:contains('We found an Energy Performance Certificate that might be yours')")
+    page = _check_page(page, "epc", "accept_suggested_epc", "Yes")
+
+    page = _check_page(page, "benefits", "benefits", "Yes")
+
+    assert page.has_one("h1:contains('What kind of property do you have?')")
+    page = _check_page(page, "property-type", "property_type", "House")
+
+    assert page.has_one("h1:contains('What kind of house do you have?')")
+    page = _check_page(page, "property-subtype", "property_subtype", "Detached")
+
+    assert page.has_one("h1:contains('How many bedrooms does the property have?')")
+    page = _check_page(page, "number-of-bedrooms", "number_of_bedrooms", "Two bedrooms")
+
+    assert page.has_one("h1:contains('What kind of walls does your property have?')")
+    page = _check_page(page, "wall-type", "wall_type", "Cavity walls")
+
+    assert page.has_one("h1:contains('Are your walls insulated?')")
+    page = _check_page(page, "wall-insulation", "wall_insulation", "No they are not insulated")
+
+    assert page.has_one("h1:contains('Do you have a loft that has not been converted into a room?')")
+    if has_loft_insulation:
+        page = _check_page(page, "loft", "loft", "Yes, I have a loft that has not been converted into a room")
+
+        assert page.has_one("h1:contains('Is there access to your loft?')")
+        page = _check_page(page, "loft-access", "loft_access", "Yes, there is access to my loft")
+
+        assert page.has_one("h1:contains('How much loft insulation do you have?')")
+        page = _check_page(page, "loft-insulation", "loft_insulation", "I have up to 100mm of loft insulation")
+    else:
+        page = _check_page(page, "loft", "loft", "No, I do not have a loft or my loft has been converted into a room")
+
+    assert page.has_one("h1:contains('Check your answers')")
+
+    page = page.click(contains="Back")
+
+    if has_loft_insulation:
+        assert page.has_one("h1:contains('How much loft insulation do you have?')")
+    else:
+        assert page.has_one("h1:contains('Do you have a loft that has not been converted into a room?')")


### PR DESCRIPTION
closes [PC-900](https://beisdigital.atlassian.net/browse/PC-900)

adds a back link exception in a similar style to [PC-898](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/pull/295), depending on the answer to the loft question

adds a verifying test, though it is quite large since it needs to nearly (but not quite) complete the whole flow. another option would be to utilise a flow finishing function & have the test press the back button twice