### PR TITLE
PC-899: Fix backlinks for Special supplier warning pages (Shell, Bulb and Utility Warehouse)

### DIFF
--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -345,11 +345,15 @@ class OwnPropertyView(PageView):
             return prev_page_url, next_page_url
         elif request_supplier == "Utility Warehouse":
             _, next_page_url = get_prev_next_urls(session_id, page_name)
-            prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="utility-warehouse-warning-page"))
+            prev_page_url = reverse(
+                "frontdoor:page", kwargs=dict(session_id=session_id, page_name="utility-warehouse-warning-page")
+            )
             return prev_page_url, next_page_url
         elif request_supplier == "Shell":
             _, next_page_url = get_prev_next_urls(session_id, page_name)
-            prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="shell-warning-page"))
+            prev_page_url = reverse(
+                "frontdoor:page", kwargs=dict(session_id=session_id, page_name="shell-warning-page")
+            )
             return prev_page_url, next_page_url
         else:
             return super().get_prev_next_urls(session_id, page_name)

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -340,15 +340,15 @@ class OwnPropertyView(PageView):
         session_data = interface.api.session.get_session(session_id)
         request_supplier = session_data.get("supplier")
         prev_page_url, next_page_url = super().get_prev_next_urls(session_id, page_name)
-        if request_supplier == "Bulb, now part of Octopus Energy":
-            prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="bulb-warning-page"))
-        elif request_supplier == "Utility Warehouse":
+        acquired_supplier_warning_pages = {
+            "Bulb, now part of Octopus Energy": "bulb-warning-page",
+            "Utility Warehouse": "utility-warehouse-warning-page",
+            "Shell": "shell-warning-page",
+        }
+        if request_supplier in acquired_supplier_warning_pages:
             prev_page_url = reverse(
-                "frontdoor:page", kwargs=dict(session_id=session_id, page_name="utility-warehouse-warning-page")
-            )
-        elif request_supplier == "Shell":
-            prev_page_url = reverse(
-                "frontdoor:page", kwargs=dict(session_id=session_id, page_name="shell-warning-page")
+                "frontdoor:page",
+                kwargs=dict(session_id=session_id, page_name=acquired_supplier_warning_pages[request_supplier]),
             )
         return prev_page_url, next_page_url
 

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -336,6 +336,24 @@ class OwnPropertyView(PageView):
 
         return redirect("frontdoor:page", session_id=session_id, page_name=next_page_name)
 
+    def get_prev_next_urls(self, session_id, page_name):
+        session_data = interface.api.session.get_session(session_id)
+        request_supplier = session_data.get("supplier")
+        if request_supplier == "Bulb, now part of Octopus Energy":
+            _, next_page_url = get_prev_next_urls(session_id, page_name)
+            prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="bulb-warning-page"))
+            return prev_page_url, next_page_url
+        elif request_supplier == "Utility Warehouse":
+            _, next_page_url = get_prev_next_urls(session_id, page_name)
+            prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="utility-warehouse-warning-page"))
+            return prev_page_url, next_page_url
+        elif request_supplier == "Shell":
+            _, next_page_url = get_prev_next_urls(session_id, page_name)
+            prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="shell-warning-page"))
+            return prev_page_url, next_page_url
+        else:
+            return super().get_prev_next_urls(session_id, page_name)
+
 
 @register_page("park-home")
 class ParkHomeView(PageView):

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -339,24 +339,18 @@ class OwnPropertyView(PageView):
     def get_prev_next_urls(self, session_id, page_name):
         session_data = interface.api.session.get_session(session_id)
         request_supplier = session_data.get("supplier")
+        prev_page_url, next_page_url = super().get_prev_next_urls(session_id, page_name)
         if request_supplier == "Bulb, now part of Octopus Energy":
-            _, next_page_url = get_prev_next_urls(session_id, page_name)
             prev_page_url = reverse("frontdoor:page", kwargs=dict(session_id=session_id, page_name="bulb-warning-page"))
-            return prev_page_url, next_page_url
         elif request_supplier == "Utility Warehouse":
-            _, next_page_url = get_prev_next_urls(session_id, page_name)
             prev_page_url = reverse(
                 "frontdoor:page", kwargs=dict(session_id=session_id, page_name="utility-warehouse-warning-page")
             )
-            return prev_page_url, next_page_url
         elif request_supplier == "Shell":
-            _, next_page_url = get_prev_next_urls(session_id, page_name)
             prev_page_url = reverse(
                 "frontdoor:page", kwargs=dict(session_id=session_id, page_name="shell-warning-page")
             )
-            return prev_page_url, next_page_url
-        else:
-            return super().get_prev_next_urls(session_id, page_name)
+        return prev_page_url, next_page_url
 
 
 @register_page("park-home")

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -303,6 +303,92 @@ def test_back_button():
     form = page.get_form()
     assert form["country"] == "England"
 
+def test_own_property_back_button_with_shell_should_return_to_shell_warning_page():
+    client = utils.get_client()
+    page = client.get("/start")
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.status_code == 200
+    session_id = page.path.split("/")[1]
+    assert uuid.UUID(session_id)
+    _check_page = _make_check_page(session_id)
+
+    form = page.get_form()
+    form["country"] = "England"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    form["supplier"] = "Shell"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    assert page.has_text("Shell is now owned by Octopus Energy.")
+    page = form.submit().follow()
+
+    assert page.has_text("Do you own the property?")
+
+    page = page.click(contains="Back")
+
+    assert page.has_text("Shell is now owned by Octopus Energy.")
+
+def test_own_property_back_button_with_bulb_should_return_to_bulb_warning_page():
+    client = utils.get_client()
+    page = client.get("/start")
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.status_code == 200
+    session_id = page.path.split("/")[1]
+    assert uuid.UUID(session_id)
+    _check_page = _make_check_page(session_id)
+
+    form = page.get_form()
+    form["country"] = "England"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    form["supplier"] = "Bulb, now part of Octopus Energy"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    assert page.has_text("Bulb is now owned by Octopus Energy.")
+    page = form.submit().follow()
+
+    assert page.has_text("Do you own the property?")
+
+    page = page.click(contains="Back")
+
+    assert page.has_text("Bulb is now owned by Octopus Energy.")
+
+def test_own_property_back_button_with_utility_warehouse_should_return_to_utility_warehouse_warning_page():
+    client = utils.get_client()
+    page = client.get("/start")
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.status_code == 200
+    session_id = page.path.split("/")[1]
+    assert uuid.UUID(session_id)
+    _check_page = _make_check_page(session_id)
+
+    form = page.get_form()
+    form["country"] = "England"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    form["supplier"] = "Utility Warehouse"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    assert page.has_text("Referral requests from UW customers will be managed by E.ON Next")
+    page = form.submit().follow()
+
+    assert page.has_text("Do you own the property?")
+
+    page = page.click(contains="Back")
+
+    assert page.has_text("Referral requests from UW customers will be managed by E.ON Next")
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockNotFoundEPCApi)
 @unittest.mock.patch("help_to_heat.frontdoor.interface.OSApi", MockOSApi)
@@ -520,7 +606,6 @@ def test_property_type_back_button_with_social_housing_and_scotland_should_retur
     page = page.click(contains="Back")
 
     assert page.has_one('h1:contains("What is the property\'s address?")')
-
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApiWithEPCC)
 def test_no_benefits_flow():

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -318,17 +318,15 @@ def test_own_property_back_button_with_supplier_should_return_to_supplier_warnin
     assert page.status_code == 302
     page = page.follow()
 
+
     assert page.status_code == 200
     session_id = page.path.split("/")[1]
     assert uuid.UUID(session_id)
+    _check_page = _make_check_page(session_id)
 
-    form = page.get_form()
-    form["country"] = "England"
-    page = form.submit().follow()
+    page = _check_page(page, "country", "country", "England")
 
-    form = page.get_form()
-    form["supplier"] = supplier_name
-    page = form.submit().follow()
+    page = _check_page(page, "supplier", "supplier", supplier_name)
 
     form = page.get_form()
     assert page.has_text(expected_text)

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -303,6 +303,7 @@ def test_back_button():
     form = page.get_form()
     assert form["country"] == "England"
 
+
 def test_own_property_back_button_with_shell_should_return_to_shell_warning_page():
     client = utils.get_client()
     page = client.get("/start")
@@ -312,7 +313,6 @@ def test_own_property_back_button_with_shell_should_return_to_shell_warning_page
     assert page.status_code == 200
     session_id = page.path.split("/")[1]
     assert uuid.UUID(session_id)
-    _check_page = _make_check_page(session_id)
 
     form = page.get_form()
     form["country"] = "England"
@@ -332,6 +332,7 @@ def test_own_property_back_button_with_shell_should_return_to_shell_warning_page
 
     assert page.has_text("Shell is now owned by Octopus Energy.")
 
+
 def test_own_property_back_button_with_bulb_should_return_to_bulb_warning_page():
     client = utils.get_client()
     page = client.get("/start")
@@ -341,7 +342,6 @@ def test_own_property_back_button_with_bulb_should_return_to_bulb_warning_page()
     assert page.status_code == 200
     session_id = page.path.split("/")[1]
     assert uuid.UUID(session_id)
-    _check_page = _make_check_page(session_id)
 
     form = page.get_form()
     form["country"] = "England"
@@ -361,6 +361,7 @@ def test_own_property_back_button_with_bulb_should_return_to_bulb_warning_page()
 
     assert page.has_text("Bulb is now owned by Octopus Energy.")
 
+
 def test_own_property_back_button_with_utility_warehouse_should_return_to_utility_warehouse_warning_page():
     client = utils.get_client()
     page = client.get("/start")
@@ -370,7 +371,6 @@ def test_own_property_back_button_with_utility_warehouse_should_return_to_utilit
     assert page.status_code == 200
     session_id = page.path.split("/")[1]
     assert uuid.UUID(session_id)
-    _check_page = _make_check_page(session_id)
 
     form = page.get_form()
     form["country"] = "England"
@@ -389,6 +389,7 @@ def test_own_property_back_button_with_utility_warehouse_should_return_to_utilit
     page = page.click(contains="Back")
 
     assert page.has_text("Referral requests from UW customers will be managed by E.ON Next")
+
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockNotFoundEPCApi)
 @unittest.mock.patch("help_to_heat.frontdoor.interface.OSApi", MockOSApi)
@@ -606,6 +607,7 @@ def test_property_type_back_button_with_social_housing_and_scotland_should_retur
     page = page.click(contains="Back")
 
     assert page.has_one('h1:contains("What is the property\'s address?")')
+
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApiWithEPCC)
 def test_no_benefits_flow():

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -304,7 +304,15 @@ def test_back_button():
     assert form["country"] == "England"
 
 
-def test_own_property_back_button_with_shell_should_return_to_shell_warning_page():
+@pytest.mark.parametrize(
+    ("supplier_name", "expected_text"),
+    [
+        ("Shell", "Shell is now owned by Octopus Energy."),
+        ("Bulb, now part of Octopus Energy", "Bulb is now owned by Octopus Energy."),
+        ("Utility Warehouse", "Referral requests from UW customers will be managed by E.ON Next"),
+    ],
+)
+def test_own_property_back_button_with_supplier_should_return_to_supplier_warning_page(supplier_name, expected_text):
     client = utils.get_client()
     page = client.get("/start")
     assert page.status_code == 302
@@ -319,76 +327,18 @@ def test_own_property_back_button_with_shell_should_return_to_shell_warning_page
     page = form.submit().follow()
 
     form = page.get_form()
-    form["supplier"] = "Shell"
+    form["supplier"] = supplier_name
     page = form.submit().follow()
 
     form = page.get_form()
-    assert page.has_text("Shell is now owned by Octopus Energy.")
+    assert page.has_text(expected_text)
     page = form.submit().follow()
 
     assert page.has_text("Do you own the property?")
 
     page = page.click(contains="Back")
 
-    assert page.has_text("Shell is now owned by Octopus Energy.")
-
-
-def test_own_property_back_button_with_bulb_should_return_to_bulb_warning_page():
-    client = utils.get_client()
-    page = client.get("/start")
-    assert page.status_code == 302
-    page = page.follow()
-
-    assert page.status_code == 200
-    session_id = page.path.split("/")[1]
-    assert uuid.UUID(session_id)
-
-    form = page.get_form()
-    form["country"] = "England"
-    page = form.submit().follow()
-
-    form = page.get_form()
-    form["supplier"] = "Bulb, now part of Octopus Energy"
-    page = form.submit().follow()
-
-    form = page.get_form()
-    assert page.has_text("Bulb is now owned by Octopus Energy.")
-    page = form.submit().follow()
-
-    assert page.has_text("Do you own the property?")
-
-    page = page.click(contains="Back")
-
-    assert page.has_text("Bulb is now owned by Octopus Energy.")
-
-
-def test_own_property_back_button_with_utility_warehouse_should_return_to_utility_warehouse_warning_page():
-    client = utils.get_client()
-    page = client.get("/start")
-    assert page.status_code == 302
-    page = page.follow()
-
-    assert page.status_code == 200
-    session_id = page.path.split("/")[1]
-    assert uuid.UUID(session_id)
-
-    form = page.get_form()
-    form["country"] = "England"
-    page = form.submit().follow()
-
-    form = page.get_form()
-    form["supplier"] = "Utility Warehouse"
-    page = form.submit().follow()
-
-    form = page.get_form()
-    assert page.has_text("Referral requests from UW customers will be managed by E.ON Next")
-    page = form.submit().follow()
-
-    assert page.has_text("Do you own the property?")
-
-    page = page.click(contains="Back")
-
-    assert page.has_text("Referral requests from UW customers will be managed by E.ON Next")
+    assert page.has_text(expected_text)
 
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockNotFoundEPCApi)


### PR DESCRIPTION
Added special cases to own-property backlinks where supplier is Bulb, Utility Warehouse, or Shell to go back to their appropriate warning page.

Added tests for these special cases too, to ensure they're working correctly.