### PR TITLE
PC-971 Park homes questions incorrectly served when user changes answers from home owner to social housing

### DIFF
--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -161,9 +161,9 @@ def get_prev_next_page_name(page_name, session_id=None):
         is_social_housing = session_data.get("own_property") == "No, I am a social housing tenant"
         receives_benefits = session_data.get("benefits") == "Yes"
 
+    # This question is asked first, so this path should take precedence in case users have
+    # gone back and changed their answers
     if is_social_housing:
-        # This question is asked first, so this path should take precedence in case users have
-        # gone back and changed their answers
         mapping = schemas.page_prev_next_map_social_housing
         order = schemas.page_order_social_housing
     elif is_park_home:

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -161,7 +161,7 @@ def get_prev_next_page_name(page_name, session_id=None):
         is_social_housing = session_data.get("own_property") == "No, I am a social housing tenant"
         receives_benefits = session_data.get("benefits") == "Yes"
 
-    if is_social_housing:
+    if is_social_housing:  # This question is asked first, so this path should be checked first to take precedence
         mapping = schemas.page_prev_next_map_social_housing
         order = schemas.page_order_social_housing
     elif is_park_home:

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -161,12 +161,12 @@ def get_prev_next_page_name(page_name, session_id=None):
         is_social_housing = session_data.get("own_property") == "No, I am a social housing tenant"
         receives_benefits = session_data.get("benefits") == "Yes"
 
-    if is_park_home:
-        mapping = schemas.page_prev_next_map_park_home
-        order = schemas.page_order_park_home
-    elif is_social_housing:
+    if is_social_housing:
         mapping = schemas.page_prev_next_map_social_housing
         order = schemas.page_order_social_housing
+    elif is_park_home:
+        mapping = schemas.page_prev_next_map_park_home
+        order = schemas.page_order_park_home
     else:
         mapping = schemas.page_prev_next_map
         order = schemas.page_order

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -161,7 +161,9 @@ def get_prev_next_page_name(page_name, session_id=None):
         is_social_housing = session_data.get("own_property") == "No, I am a social housing tenant"
         receives_benefits = session_data.get("benefits") == "Yes"
 
-    if is_social_housing:  # This question is asked first, so this path should be checked first to take precedence
+    if is_social_housing:
+        # This question is asked first, so this path should take precedence in case users have
+        # gone back and changed their answers
         mapping = schemas.page_prev_next_map_social_housing
         order = schemas.page_order_social_housing
     elif is_park_home:

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -735,9 +735,12 @@ class SummaryView(PageView):
         question_answered = question in session_data and question in schemas.summary_map
         if not question_answered:
             return False
-        if question == "property_type" or question == "property_subtype":
+        if question in ["property_type", "property_subtype"]:
             property_type = self.get_answer(session_data, "property_type")
             return property_type != "Park home"
+        if question in ["park_home", "park_home_main_residence"]:
+            own_property = self.get_answer(session_data, "own_property")
+            return own_property != "No, I am a social housing tenant"
         if question == "epc_rating":
             epc_rating = session_data.get("epc_rating", "Not found")
             accept_suggested_epc = session_data.get("accept_suggested_epc")

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -75,7 +75,7 @@ def test_flow_errors():
 
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApi)
-def _answer_house_questions(page, session_id, benefits_answer, supplier="Utilita"):
+def _answer_house_questions(page, session_id, benefits_answer, supplier="Utilita", park_home=False):
     """Answer main flow with set answers"""
 
     _check_page = _make_check_page(session_id)
@@ -105,7 +105,11 @@ def _answer_house_questions(page, session_id, benefits_answer, supplier="Utilita
     page = _check_page(page, "own-property", "own_property", "Yes, I own my property and live in it")
 
     assert page.has_text("Do you live in a park home")
-    page = _check_page(page, "park-home", "park_home", "No")
+    page = _check_page(page, "park-home", "park_home", "No" if not park_home else "Yes")
+
+    if park_home:
+        assert page.has_text("Is the park home your main residence?")
+        page = _check_page(page, "park-home-main-residence", "park_home_main_residence", "Yes")
 
     form = page.get_form()
     form["building_name_or_number"] = "22"
@@ -120,8 +124,9 @@ def _answer_house_questions(page, session_id, benefits_answer, supplier="Utilita
     assert data["rrn"] == "2222-2222-2222-2222-2222"
     assert data["address"] == "22 Acacia Avenue, Upper Wellgood, Fulchester, FL23 4JA"
 
-    assert page.has_one("h1:contains('What is the council tax band of your property?')")
-    page = _check_page(page, "council-tax-band", "council_tax_band", "B")
+    if not park_home:
+        assert page.has_one("h1:contains('What is the council tax band of your property?')")
+        page = _check_page(page, "council-tax-band", "council_tax_band", "B")
 
     assert page.has_one("h1:contains('We found an Energy Performance Certificate that might be yours')")
     page = _check_page(page, "epc", "accept_suggested_epc", "Yes")
@@ -132,29 +137,30 @@ def _answer_house_questions(page, session_id, benefits_answer, supplier="Utilita
         assert page.has_one("h1:contains('What is your annual household income?')")
         page = _check_page(page, "household-income", "household_income", "Less than £31,000 a year")
 
-    assert page.has_one("h1:contains('What kind of property do you have?')")
-    page = _check_page(page, "property-type", "property_type", "House")
+    if not park_home:
+        assert page.has_one("h1:contains('What kind of property do you have?')")
+        page = _check_page(page, "property-type", "property_type", "House")
 
-    assert page.has_one("h1:contains('What kind of house do you have?')")
-    page = _check_page(page, "property-subtype", "property_subtype", "Detached")
+        assert page.has_one("h1:contains('What kind of house do you have?')")
+        page = _check_page(page, "property-subtype", "property_subtype", "Detached")
 
-    assert page.has_one("h1:contains('How many bedrooms does the property have?')")
-    page = _check_page(page, "number-of-bedrooms", "number_of_bedrooms", "Two bedrooms")
+        assert page.has_one("h1:contains('How many bedrooms does the property have?')")
+        page = _check_page(page, "number-of-bedrooms", "number_of_bedrooms", "Two bedrooms")
 
-    assert page.has_one("h1:contains('What kind of walls does your property have?')")
-    page = _check_page(page, "wall-type", "wall_type", "Cavity walls")
+        assert page.has_one("h1:contains('What kind of walls does your property have?')")
+        page = _check_page(page, "wall-type", "wall_type", "Cavity walls")
 
-    assert page.has_one("h1:contains('Are your walls insulated?')")
-    page = _check_page(page, "wall-insulation", "wall_insulation", "No they are not insulated")
+        assert page.has_one("h1:contains('Are your walls insulated?')")
+        page = _check_page(page, "wall-insulation", "wall_insulation", "No they are not insulated")
 
-    assert page.has_one("""h1:contains("Do you have a loft that has not been converted into a room?")""")
-    page = _check_page(page, "loft", "loft", "Yes, I have a loft that has not been converted into a room")
+        assert page.has_one("""h1:contains("Do you have a loft that has not been converted into a room?")""")
+        page = _check_page(page, "loft", "loft", "Yes, I have a loft that has not been converted into a room")
 
-    assert page.has_one("h1:contains('Is there access to your loft?')")
-    page = _check_page(page, "loft-access", "loft_access", "Yes, there is access to my loft")
+        assert page.has_one("h1:contains('Is there access to your loft?')")
+        page = _check_page(page, "loft-access", "loft_access", "Yes, there is access to my loft")
 
-    assert page.has_one("h1:contains('How much loft insulation do you have?')")
-    page = _check_page(page, "loft-insulation", "loft_insulation", "I have up to 100mm of loft insulation")
+        assert page.has_one("h1:contains('How much loft insulation do you have?')")
+        page = _check_page(page, "loft-insulation", "loft_insulation", "I have up to 100mm of loft insulation")
 
     assert page.has_one("h1:contains('Check your answers')")
     form = page.get_form()
@@ -257,6 +263,21 @@ def _make_check_page(session_id):
         return page
 
     return _check_page
+
+
+def _click_change_button(page, page_name):
+    client = utils.get_client()
+    els = page.all("a:contains('Change')")
+    change = next(filter(lambda el: f"/{page_name}/change/" in el.attrib["href"], els), None)
+    assert change is not None
+    url = change.attrib["href"]
+    return client.get(url)
+
+
+def _assert_change_button_is_hidden(page, page_name):
+    els = page.all("a:contains('Change')")
+    change = next(filter(lambda el: f"/{page_name}/change/" in el.attrib["href"], els), None)
+    assert change is None
 
 
 def test_back_button():
@@ -1352,3 +1373,33 @@ def test_on_check_page_back_button_goes_to_correct_location(has_loft_insulation)
         assert page.has_one("h1:contains('How much loft insulation do you have?')")
     else:
         assert page.has_one("h1:contains('Do you have a loft that has not been converted into a room?')")
+
+
+@unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApi)
+@pytest.mark.parametrize("park_home", [True, False])
+def test_on_check_answers_page_changing_to_social_housing_hides_park_home_question(park_home):
+    client = utils.get_client()
+    page = client.get("/start")
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.status_code == 200
+    session_id = page.path.split("/")[1]
+    assert uuid.UUID(session_id)
+    _check_page = _make_check_page(session_id)
+
+    # Answer main flow
+    page = _answer_house_questions(page, session_id, benefits_answer="Yes", park_home=park_home)
+
+    # press back to get to summary page
+    page = page.click(contains="Back")
+    assert page.has_one("h1:contains('Check your answers')")
+
+    page = _click_change_button(page, "own-property")
+    assert page.has_text("Do you own the property?")
+
+    page = _check_page(page, "own-property", "own_property","No, I am a social housing tenant")
+    assert page.has_one("h1:contains('Check your answers')")
+
+    _assert_change_button_is_hidden(page, "park-home")
+    _assert_change_button_is_hidden(page, "park-home-main-residence")

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -267,16 +267,16 @@ def _make_check_page(session_id):
 
 def _click_change_button(page, page_name):
     client = utils.get_client()
-    els = page.all("a:contains('Change')")
-    change = next(filter(lambda el: f"/{page_name}/change/" in el.attrib["href"], els), None)
+    elements = page.all("a:contains('Change')")
+    change = next(filter(lambda el: f"/{page_name}/change/" in el.attrib["href"], elements), None)
     assert change is not None
     url = change.attrib["href"]
     return client.get(url)
 
 
 def _assert_change_button_is_hidden(page, page_name):
-    els = page.all("a:contains('Change')")
-    change = next(filter(lambda el: f"/{page_name}/change/" in el.attrib["href"], els), None)
+    elements = page.all("a:contains('Change')")
+    change = next(filter(lambda el: f"/{page_name}/change/" in el.attrib["href"], elements), None)
     assert change is None
 
 
@@ -1374,6 +1374,7 @@ def test_on_check_page_back_button_goes_to_correct_location(has_loft_insulation)
     else:
         assert page.has_one("h1:contains('Do you have a loft that has not been converted into a room?')")
 
+
 def test_switching_path_to_social_housing_does_not_ask_park_home_questions_again():
     client = utils.get_client()
     page = client.get("/start")
@@ -1432,7 +1433,7 @@ def test_on_check_answers_page_changing_to_social_housing_hides_park_home_questi
     page = _click_change_button(page, "own-property")
     assert page.has_text("Do you own the property?")
 
-    page = _check_page(page, "own-property", "own_property","No, I am a social housing tenant")
+    page = _check_page(page, "own-property", "own_property", "No, I am a social housing tenant")
     assert page.has_one("h1:contains('Check your answers')")
 
     _assert_change_button_is_hidden(page, "park-home")


### PR DESCRIPTION
closes [PC-971](https://beisdigital.atlassian.net/browse/PC-971)

the main issue is that the park home check took priority over the social housing check for deciding which flow the user is on. swapping the check fixes the issue of incorrect flow

also to fix the issue of the question appearing on the check answers page a new exception has been added to hide it when needed

added some tests to verify this. contains a few upgrades for tests
- functions to interface with the change buttons
- add a park home option when answering house questions