### PR TITLE
PC-1008: Removing Ecotricity from the list of suppliers page

### DIFF
--- a/help_to_heat/frontdoor/schemas.py
+++ b/help_to_heat/frontdoor/schemas.py
@@ -575,10 +575,6 @@ supplier_options = (
         "value": "E (Gas & Electricity) Ltd",
     },
     {
-        "label": "Ecotricity",
-        "value": "Ecotricity",
-    },
-    {
         "label": "EDF",
         "value": "EDF",
     },


### PR DESCRIPTION
closes [PC-1008](https://beisdigital.atlassian.net/browse/PC-1008)

follows a the same format as https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/pull/270, where the supplier is removed only from frontdoor flow & not from the backend schema

![image](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/assets/108681823/dbfee78e-9c2c-4cc4-8e16-456dc7e9081f)