### PR TITLE
PC 994 prevent incompatible loft answers in change page

### DIFF
--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -765,7 +765,7 @@ class SummaryView(PageView):
             return epc_rating != "Not found" and accept_suggested_epc == "Yes"
         if question in ["loft_access", "loft_insulation"]:
             loft_answer = self.get_answer(session_data, "loft")
-            return loft_answer != "No, I do not have a loft or my loft has been converted into a room"
+            return loft_answer == "Yes, I have a loft that has not been converted into a room"
         else:
             return True
 

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -763,6 +763,9 @@ class SummaryView(PageView):
             epc_rating = session_data.get("epc_rating", "Not found")
             accept_suggested_epc = session_data.get("accept_suggested_epc")
             return epc_rating != "Not found" and accept_suggested_epc == "Yes"
+        if question in ["loft_access", "loft_insulation"]:
+            loft_answer = self.get_answer(session_data, "loft")
+            return loft_answer != "No, I do not have a loft or my loft has been converted into a room"
         else:
             return True
 

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -1463,7 +1463,7 @@ def test_switching_path_to_social_housing_does_not_ask_park_home_questions_again
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApi)
 def test_on_check_answers_page_changing_to_social_housing_hides_park_home_question():
-    _check_page, page, session_id = setup_client_and_page()
+    _check_page, page, session_id = _setup_client_and_page()
 
     # Answer main flow
     page = _answer_house_questions(page, session_id, benefits_answer="Yes")
@@ -1487,7 +1487,7 @@ def test_on_check_answers_page_changing_to_social_housing_hides_park_home_questi
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApi)
 @pytest.mark.parametrize("park_home", [True, False])
 def test_on_check_answers_page_if_park_home_main_residence_is_hidden_depending_on_park_home_answer(park_home):
-    _check_page, page, session_id = setup_client_and_page()
+    _check_page, page, session_id = _setup_client_and_page()
 
     # Answer main flow
     page = _answer_house_questions(page, session_id, benefits_answer="Yes", park_home=park_home)
@@ -1504,7 +1504,7 @@ def test_on_check_answers_page_if_park_home_main_residence_is_hidden_depending_o
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApi)
 def test_on_check_answers_page_changing_to_no_loft_hides_loft_follow_up_questions():
-    _check_page, page, session_id = setup_client_and_page()
+    _check_page, page, session_id = _setup_client_and_page()
 
     # Answer main flow
     page = _answer_house_questions(page, session_id, benefits_answer="Yes", has_loft=True)
@@ -1526,7 +1526,7 @@ def test_on_check_answers_page_changing_to_no_loft_hides_loft_follow_up_question
     _assert_change_button_is_hidden(page, "loft-insulation")
 
 
-def setup_client_and_page():
+def _setup_client_and_page():
     client = utils.get_client()
     page = client.get("/start")
     assert page.status_code == 302

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -75,7 +75,7 @@ def test_flow_errors():
 
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApi)
-def _answer_house_questions(page, session_id, benefits_answer, supplier="Utilita", park_home=False, has_loft = True):
+def _answer_house_questions(page, session_id, benefits_answer, supplier="Utilita", park_home=False, has_loft=True):
     """Answer main flow with set answers"""
 
     _check_page = _make_check_page(session_id)
@@ -163,8 +163,9 @@ def _answer_house_questions(page, session_id, benefits_answer, supplier="Utilita
             assert page.has_one("h1:contains('How much loft insulation do you have?')")
             page = _check_page(page, "loft-insulation", "loft_insulation", "I have up to 100mm of loft insulation")
         else:
-            page = _check_page(page, "loft", "loft",
-                               "No, I do not have a loft or my loft has been converted into a room")
+            page = _check_page(
+                page, "loft", "loft", "No, I do not have a loft or my loft has been converted into a room"
+            )
 
     assert page.has_one("h1:contains('Check your answers')")
     form = page.get_form()
@@ -289,6 +290,7 @@ def _assert_change_button_is_not_hidden(page, page_name):
     change = next(filter(lambda el: f"/{page_name}/change/" in el.attrib["href"], elements), None)
     assert change is not None
 
+
 def test_back_button():
     client = utils.get_client()
     page = client.get("/start")
@@ -347,7 +349,6 @@ def test_own_property_back_button_with_supplier_should_return_to_supplier_warnin
     page = client.get("/start")
     assert page.status_code == 302
     page = page.follow()
-
 
     assert page.status_code == 200
     session_id = page.path.split("/")[1]
@@ -1482,6 +1483,7 @@ def test_on_check_answers_page_changing_to_social_housing_hides_park_home_questi
 
     _assert_change_button_is_hidden(page, "park-home")
     _assert_change_button_is_hidden(page, "park-home-main-residence")
+
 
 @unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApi)
 def test_on_check_answers_page_changing_to_no_loft_hides_loft_follow_up_questions():


### PR DESCRIPTION
Change to prevent users changing (or even seeing) follow up questions regarding their loft, should they specify that they do not have one.

When the user answers yes: 
![image](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/assets/152421975/20fc2acf-333f-40c6-b050-d693a5406408)
When the user answers no: 
![image](https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/assets/152421975/44d218ef-7729-4dfa-81fe-600931cf4670)
