### PR TITLE
PC-1135: Improve error logging

### DIFF
--- a/help_to_heat/middleware.py
+++ b/help_to_heat/middleware.py
@@ -1,6 +1,9 @@
 import logging
 
-logger = logging.getLogger(__name__)
+from django.core.handlers.wsgi import WSGIRequest
+
+logger = logging.getLogger("django.server")
+
 
 class ExceptionMiddleware:
     def __init__(self, get_response):
@@ -14,3 +17,12 @@ class ExceptionMiddleware:
         # print out to AWS logs
         logger.exception(exception)
         return None
+
+
+class RequestLoggingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request: WSGIRequest):
+        logger.info(f"{request.method}: {request.path}")
+        return self.get_response(request)

--- a/help_to_heat/middleware.py
+++ b/help_to_heat/middleware.py
@@ -1,0 +1,16 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+class ExceptionMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # pass requests down the stack without edits
+        return self.get_response(request)
+
+    def process_exception(self, _request, exception):
+        # print out to AWS logs
+        logger.exception(exception)
+        return None

--- a/help_to_heat/middleware.py
+++ b/help_to_heat/middleware.py
@@ -25,6 +25,5 @@ class RequestLoggingMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: WSGIRequest):
-        # when required uncomment for request logging
-        # requests_logger.info(f"{request.method}: {request.path}")
+        requests_logger.info(f"{request.method}: {request.path}")
         return self.get_response(request)

--- a/help_to_heat/middleware.py
+++ b/help_to_heat/middleware.py
@@ -2,7 +2,8 @@ import logging
 
 from django.core.handlers.wsgi import WSGIRequest
 
-logger = logging.getLogger("django.server")
+middleware_logger = logging.getLogger(__name__)
+requests_logger = logging.getLogger("requests")
 
 
 class ExceptionMiddleware:
@@ -15,7 +16,7 @@ class ExceptionMiddleware:
 
     def process_exception(self, _request, exception):
         # print out to AWS logs
-        logger.exception(exception)
+        middleware_logger.exception(exception)
         return None
 
 
@@ -24,5 +25,5 @@ class RequestLoggingMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: WSGIRequest):
-        logger.info(f"{request.method}: {request.path}")
+        requests_logger.info(f"{request.method}: {request.path}")
         return self.get_response(request)

--- a/help_to_heat/middleware.py
+++ b/help_to_heat/middleware.py
@@ -2,8 +2,8 @@ import logging
 
 from django.core.handlers.wsgi import WSGIRequest
 
-middleware_logger = logging.getLogger(__name__)
-requests_logger = logging.getLogger("requests")
+logger = logging.getLogger(__name__)
+requests_logger = logging.getLogger("help_to_heat.requests")
 
 
 class ExceptionMiddleware:
@@ -16,7 +16,7 @@ class ExceptionMiddleware:
 
     def process_exception(self, _request, exception):
         # print out to AWS logs
-        middleware_logger.exception(exception)
+        logger.exception(exception)
         return None
 
 
@@ -25,5 +25,6 @@ class RequestLoggingMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: WSGIRequest):
-        requests_logger.info(f"{request.method}: {request.path}")
+        # when required uncomment for request logging
+        # requests_logger.info(f"{request.method}: {request.path}")
         return self.get_response(request)

--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -224,24 +224,38 @@ else:
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "formatters": {
-        "requests": {
-            "()": "django.utils.log.ServerFormatter",
-            "format": "[{server_time}] {message}",
-            "style": "{",
-        }
-    },
-    "handlers": {
-        "requests": {
+    "loggers": {
+        "help_to_heat": {
+            "handlers": ["console_verbose"],
             "level": "INFO",
-            "class": "logging.StreamHandler",
-            "formatter": "requests",
+            "propagate": False,
+        },
+        "help_to_heat.requests": {
+            "handlers": ["console_simple"],
+            "level": "INFO",
+            "propagate": False,
         },
     },
-    "loggers": {
-        "requests": {
-            "handlers": ["requests"],
-            "level": "INFO",
+    "handlers": {
+        "console_simple": {
+            "class": "logging.StreamHandler",
+            "formatter": "simple",
+        },
+        "console_verbose": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+    },
+    "formatters": {
+        "simple": {
+            "()": "django.utils.log.ServerFormatter",
+            "format": "[{server_time}] [{levelname}] {message}",
+            "style": "{",
+        },
+        "verbose": {
+            "()": "django.utils.log.ServerFormatter",
+            "format": "[{server_time}] [{levelname}] {pathname}:{funcName}:{lineno} {message}",
+            "style": "{",
         },
     },
 }

--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -65,6 +65,7 @@ CORS_APPS = [
 ]
 
 MIDDLEWARE = [
+    "help_to_heat.middleware.ExceptionMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "csp.middleware.CSPMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -234,7 +235,7 @@ if not DEBUG:
     SESSION_COOKIE_SAMESITE = "Strict"
     CSRF_COOKIE_SECURE = True
 
-    logging.getLogger("waitress.queue").setLevel(logging.ERROR)
+    # logging.getLogger("waitress.queue").setLevel(logging.ERROR)
 else:
     import debugpy
 

--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -221,6 +221,31 @@ else:
     if EMAIL_BACKEND_TYPE not in ("FILE", "CONSOLE", "GOVUKNOTIFY"):
         raise Exception(f"Unknown EMAIL_BACKEND_TYPE of {EMAIL_BACKEND_TYPE}")
 
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "requests": {
+            "()": "django.utils.log.ServerFormatter",
+            "format": "[{server_time}] {message}",
+            "style": "{",
+        }
+    },
+    "handlers": {
+        "requests": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "requests",
+        },
+    },
+    "loggers": {
+        "requests": {
+            "handlers": ["requests"],
+            "level": "INFO",
+        },
+    },
+}
+
 OS_API_KEY = env.str("OS_API_KEY")
 EPC_API_BASE_URL = env.str("EPC_API_BASE_URL")
 EPC_API_CLIENT_ID = env.str("EPC_API_CLIENT_ID")

--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -235,7 +235,7 @@ if not DEBUG:
     SESSION_COOKIE_SAMESITE = "Strict"
     CSRF_COOKIE_SECURE = True
 
-    # logging.getLogger("waitress.queue").setLevel(logging.ERROR)
+    logging.getLogger("waitress.queue").setLevel(logging.ERROR)
 else:
     import debugpy
 

--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -76,6 +76,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "help_to_heat.middleware.RequestLoggingMiddleware",
 ]
 
 

--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -65,7 +65,7 @@ CORS_APPS = [
 ]
 
 MIDDLEWARE = [
-    "help_to_heat.middleware.ExceptionMiddleware",
+    "help_to_heat.middleware.ExceptionMiddleware",  # at the top to catch all errors that bubble up
     "django.middleware.security.SecurityMiddleware",
     "csp.middleware.CSPMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -76,7 +76,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "help_to_heat.middleware.RequestLoggingMiddleware",
+    "help_to_heat.middleware.RequestLoggingMiddleware",  # at the bottom to only log requests that aren't blocked
 ]
 
 

--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -226,37 +226,28 @@ LOGGING = {
     "disable_existing_loggers": False,
     "loggers": {
         "help_to_heat": {
-            "handlers": ["console_verbose"],
+            "handlers": ["help_to_heat"],
             "level": "INFO",
             "propagate": False,
         },
         "help_to_heat.requests": {
-            "handlers": ["console_simple"],
+            "handlers": ["help_to_heat"],
             "level": "INFO",
             "propagate": False,
         },
     },
     "handlers": {
-        "console_simple": {
+        "help_to_heat": {
             "class": "logging.StreamHandler",
-            "formatter": "simple",
-        },
-        "console_verbose": {
-            "class": "logging.StreamHandler",
-            "formatter": "verbose",
-        },
+            "formatter": "help_to_heat",
+        }
     },
     "formatters": {
-        "simple": {
+        "help_to_heat": {
             "()": "django.utils.log.ServerFormatter",
             "format": "[{server_time}] [{levelname}] {message}",
             "style": "{",
-        },
-        "verbose": {
-            "()": "django.utils.log.ServerFormatter",
-            "format": "[{server_time}] [{levelname}] {pathname}:{funcName}:{lineno} {message}",
-            "style": "{",
-        },
+        }
     },
 }
 

--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -76,7 +76,8 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "help_to_heat.middleware.RequestLoggingMiddleware",  # at the bottom to only log requests that aren't blocked
+    # PC-1135: uncomment the below line when request logging is required
+    # "help_to_heat.middleware.RequestLoggingMiddleware",  # at the bottom to only log requests that aren't blocked
 ]
 
 


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1135)

# Description

adds two new middleware:
- `ExceptionMiddleware`, which intercepts and reports errors
- `RequestLoggingMiddleware`, which logs all requests

will need to be merged to dev unfortunately to be able to test these changes

# Todo
how much exactly will this cost? CloudWatch charges by the GB ingested, and is already costing ~£100 per month on current logging levels. is logging all requests going to be feasible?

can more be done with logging levels? CloudWatch doesn't appear to really have filtering for this, though it's possible to prepend ERROR or INFO to each request so the logs can be filtered

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to Python files (even if not changing any content strings), I have run `make extract-translations`
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVNyomz0g=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
