### PR TITLE
PC-1218: Fix key error if referral is missing PII

### DIFF
--- a/help_to_heat/portal/download_views.py
+++ b/help_to_heat/portal/download_views.py
@@ -271,7 +271,8 @@ def add_extra_row_data(referral, exclude_pii=False):
 
     if exclude_pii:
         for key in pii_keys:
-            row.pop(key)
+            if key in row.keys():
+                row.pop(key)
 
     eligibility = calculate_eligibility(row)
     epc_date = row.get("epc_date")

--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -235,10 +235,7 @@ LOGGING = {
             "level": "INFO",
             "propagate": False,
         },
-        "django": {
-            "handlers": ["help_to_heat"],
-            "level": "INFO"
-        }
+        "django": {"handlers": ["help_to_heat"], "level": "INFO"},
     },
     "handlers": {
         "help_to_heat": {


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1218)

# Description

add a check before popping key

this resolves a KeyError if the key is not in the object, which can happen for invalid referrals

this does not fix the root issue, but does make the export handler more resilient

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to Python files (even if not changing any content strings), I have run `make extract-translations`
