### PR TITLE
PC-NONE: update makefile to docker compose v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,44 +2,44 @@ include envs/web.template
 
 .PHONY: reset-db
 reset-db:
-	docker-compose up --detach ${POSTGRES_HOST}
-	docker-compose run ${POSTGRES_HOST} dropdb -U ${POSTGRES_USER} -h ${POSTGRES_HOST} ${POSTGRES_DB}
-	docker-compose run ${POSTGRES_HOST} createdb -U ${POSTGRES_USER} -h ${POSTGRES_HOST} ${POSTGRES_DB}
-	docker-compose kill
+	docker compose up --detach ${POSTGRES_HOST}
+	docker compose run ${POSTGRES_HOST} dropdb -U ${POSTGRES_USER} -h ${POSTGRES_HOST} ${POSTGRES_DB}
+	docker compose run ${POSTGRES_HOST} createdb -U ${POSTGRES_USER} -h ${POSTGRES_HOST} ${POSTGRES_DB}
+	docker compose kill
 
 .PHONY: add-suppliers
 add-suppliers:
-	docker-compose build web
-	docker-compose run web python manage.py add_suppliers
+	docker compose build web
+	docker compose run web python manage.py add_suppliers
 
 # -------------------------------------- Code Style  -------------------------------------
 
 .PHONY: check-python-code
 check-python-code:
-	docker-compose -f tests/docker-compose.yml build check-code-help-to-heat && docker-compose -f tests/docker-compose.yml run --no-deps --rm check-code-help-to-heat
+	docker compose -f tests/docker-compose.yml build check-code-help-to-heat && docker compose -f tests/docker-compose.yml run --no-deps --rm check-code-help-to-heat
 
 .PHONY: check-migrations
 check-migrations:
-	docker-compose build web
-	docker-compose run web python manage.py migrate
-	docker-compose run web python manage.py makemigrations --check
+	docker compose build web
+	docker compose run web python manage.py migrate
+	docker compose run web python manage.py makemigrations --check
 
 .PHONY: test
 test:
-	docker-compose -f tests/docker-compose.yml down
-	docker-compose -f tests/docker-compose.yml build tests-help-to-heat help-to-heat-test-db && docker-compose -f tests/docker-compose.yml run --rm tests-help-to-heat
-	docker-compose -f tests/docker-compose.yml down
+	docker compose -f tests/docker-compose.yml down
+	docker compose -f tests/docker-compose.yml build tests-help-to-heat help-to-heat-test-db && docker compose -f tests/docker-compose.yml run --rm tests-help-to-heat
+	docker compose -f tests/docker-compose.yml down
 
 .PHONY: psql
 psql:
-	docker-compose run ${POSTGRES_HOST} psql -U ${POSTGRES_USER} -h ${POSTGRES_HOST} ${POSTGRES_DB}
+	docker compose run ${POSTGRES_HOST} psql -U ${POSTGRES_USER} -h ${POSTGRES_HOST} ${POSTGRES_DB}
 
 .PHONY: extract-translations
 extract-translations:
-	docker-compose build web
-	docker-compose run web python manage.py makemessages --locale cy --ignore venv
+	docker compose build web
+	docker compose run web python manage.py makemessages --locale cy --ignore venv
 
 .PHONY: compile-translations
 compile-translations:
-	docker-compose build web
-	docker-compose run web python manage.py compilemessages --ignore venv
+	docker compose build web
+	docker compose run web python manage.py compilemessages --ignore venv


### PR DESCRIPTION
# Description

see https://github.com/orgs/community/discussions/116610, `docker-compose` is now deprecated & can be replaced with `docker compose`

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
