### PR TITLE
PC-1221: add a failsafe for pressing back when it's not possible to send to summary

### DIFF
--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -508,7 +508,7 @@ class PageView(utils.MethodDispatcher):
                 except CouldNotCalculateJourneyException:
                     # if not, as a failsafe send them to the previous page in change state
                     # this is a reasonably unsurprising action to the user, it is the previous page
-                    # TODO PC-1221: review further as part of PC-1311
+                    # TODO PC-1311: review further
                     prev_page_name = get_prev_page(page_name, answers)
                     return reverse(
                         "frontdoor:change-page", kwargs=dict(session_id=session_id, page_name=prev_page_name)


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1221)

# Description

this will be further reviewed at a later date as part of [PC-1311](https://beisdigital.atlassian.net/browse/PC-1311)

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to Python files (even if not changing any content strings), I have run `make extract-translations`