### PR TITLE
PC-1415: Fix pipelines not failing on code format fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ add-suppliers:
 
 # -------------------------------------- Code Style  -------------------------------------
 
+.PHONY: format-python-code
+format-python-code:
+	docker compose -f tests/docker-compose.yml build format-code-help-to-heat && docker compose -f tests/docker-compose.yml run --no-deps --rm format-code-help-to-heat
+
 .PHONY: check-python-code
 check-python-code:
 	docker compose -f tests/docker-compose.yml build check-code-help-to-heat && docker compose -f tests/docker-compose.yml run --no-deps --rm check-code-help-to-heat

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Migrations are run automatically at startup, and suppliers are added automatical
 
 ## Checking code
 
-    make check-python-code
+    make format-python-code
 
 ## Deployment
 

--- a/docker/tests/check-code.sh
+++ b/docker/tests/check-code.sh
@@ -1,8 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
-set -o nounset
 
-black .
-isort .
+if [[ $1 = "--format" ]]; then
+    black .
+    isort .
+else
+    black --check --diff .
+    isort --check --diff .
+fi
+
 flake8 .

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -19,18 +19,22 @@ services:
     expose:
       - "5432"
 
-  format-code-help-to-heat:
+  inspect-code-help-to-heat:
     build:
       context: ../
       dockerfile: ./docker/tests/Dockerfile
     image: tests_help_to_heat
     env_file:
       - ../envs/tests
-    entrypoint: bash /check-code.sh --format
     volumes:
       - ../:/app/:z
 
+  format-code-help-to-heat:
+    extends:
+      service: inspect-code-help-to-heat
+    entrypoint: bash /check-code.sh --format
+
   check-code-help-to-heat:
     extends:
-      service: format-code-help-to-heat
+      service: inspect-code-help-to-heat
     entrypoint: bash /check-code.sh

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -19,13 +19,18 @@ services:
     expose:
       - "5432"
 
+  format-code-help-to-heat:
+    build:
+      context: ../
+      dockerfile: ./docker/tests/Dockerfile
+    image: tests_help_to_heat
+    env_file:
+      - ../envs/tests
+    entrypoint: bash /check-code.sh --format
+    volumes:
+      - ../:/app/:z
+
   check-code-help-to-heat:
-      build:
-        context: ../
-        dockerfile: ./docker/tests/Dockerfile
-      image: tests_help_to_heat
-      env_file:
-        - ../envs/tests
-      entrypoint: sh /check-code.sh
-      volumes:
-        - ../:/app/:z
+    extends:
+      service: format-code-help-to-heat
+    entrypoint: bash /check-code.sh


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1415)

# Description

this ensures `black` and `isort` emit a non-zero exit code on formatting fail
`flake8` does this automatically so no changes needed here

job pre these changes: https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/actions/runs/11611247770/job/32332179284
job post these changes: https://github.com/UKGovernmentBEIS/help-to-heat-GBIS/actions/runs/11611170314/job/32331954594

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
