### PR TITLE
PC-1349: add a guard for if property type is not found

### DIFF
--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -843,7 +843,9 @@ class EpcView(PageView):
 
         epc_property_type = epc.get("property-type")
 
-        if epc_property_type.upper() in property_types:
+        if epc_property_type is None:
+            property_type = None
+        elif epc_property_type.upper() in property_types:
             property_type = property_types[epc_property_type.upper()]
         else:
             logger.error(f"Unrecognised Property Type: {epc_property_type}")


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1349)

# Description

add a guard check for if there is no property type in the user's session

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to Python files (even if not changing any content strings), I have run `make extract-translations`
