### PR TITLE
PC-1347: Routing error shown on success page

### DIFF
--- a/help_to_heat/frontdoor/schemas.py
+++ b/help_to_heat/frontdoor/schemas.py
@@ -105,6 +105,7 @@ from help_to_heat.frontdoor.consts import (
     schemes_page,
     shell_warning_page,
     shell_warning_page_field,
+    success_page,
     summary_page,
     supplier_field,
     supplier_field_british_gas,
@@ -201,10 +202,16 @@ page_display_questions = {
 # which pages should ignore routing checks
 # the code will not check if the user's route allows them to see these pages
 # a prev page url should be provided to allow the back link to work
+# or, if the page does not allow the user to go back, it may not be needed to calculate previous page
+# this means the page can be seen without any routing checks being run
+# if this is desired, set prev_page to the below constant
+no_back_button_on_page = "no-back-button-on-page"
+
 routing_overrides = {
     address_manual_page: {"prev_page": address_page},
     epc_select_manual_page: {"prev_page": epc_select_page},
     address_select_manual_page: {"prev_page": address_select_page},
+    success_page: {"prev_page": no_back_button_on_page},
 }
 
 # which change page to send back to

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -146,6 +146,7 @@ from .eligibility import calculate_eligibility, eco4
 from .routing import CouldNotCalculateJourneyException, calculate_journey
 from .routing.backwards_routing import get_prev_page
 from .routing.forwards_routing import get_next_page
+from .schemas import no_back_button_on_page
 from .session_handlers.duplicate_referral_checker import (
     DuplicateReferralChecker,
 )
@@ -556,7 +557,15 @@ class PageView(utils.MethodDispatcher):
                     )
 
         if page_name in schemas.routing_overrides:
-            return page_name_to_url(session_id, schemas.routing_overrides[page_name]["prev_page"])
+            prev_page = schemas.routing_overrides[page_name]["prev_page"]
+
+            # the page is assumed to not have a back button so this should not be shown to the user
+            # in case it ever does, provide a fallback so the user does not get into an invalid state
+            # in this case, leave them on the page they are currently on
+            if prev_page == no_back_button_on_page:
+                return page_name_to_url(session_id, page_name)
+
+            return page_name_to_url(session_id, prev_page)
 
         return page_name_to_url(session_id, get_prev_page(page_name, answers))
 

--- a/help_to_heat/locale/cy/LC_MESSAGES/django.po
+++ b/help_to_heat/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-31 09:47+0000\n"
+"POT-Creation-Date: 2024-11-07 16:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,126 +19,126 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
 "11) ? 2 : 3;\n"
 
-#: help_to_heat/frontdoor/schemas.py:141
+#: help_to_heat/frontdoor/schemas.py:142
 msgid "Country of property"
 msgstr "Gwlad yr eiddo"
 
-#: help_to_heat/frontdoor/schemas.py:142 help_to_heat/frontdoor/schemas.py:164
+#: help_to_heat/frontdoor/schemas.py:143 help_to_heat/frontdoor/schemas.py:165
 msgid "Energy supplier"
 msgstr "Cyflenwr ynni"
 
-#: help_to_heat/frontdoor/schemas.py:143
+#: help_to_heat/frontdoor/schemas.py:144
 msgctxt "summary page"
 msgid "Do you own the property?"
 msgstr "Ydy'r eiddo yn perthyn i chi?"
 
-#: help_to_heat/frontdoor/schemas.py:144
+#: help_to_heat/frontdoor/schemas.py:145
 #: help_to_heat/templates/frontdoor/park-home.html:14
 msgid "Do you live in a park home?"
 msgstr "Ydych chi'n byw mewn aelwyd mewn parc?"
 
-#: help_to_heat/frontdoor/schemas.py:145
+#: help_to_heat/frontdoor/schemas.py:146
 #: help_to_heat/templates/frontdoor/park-home-main-residence.html:14
 msgid "Is the park home your main residence?"
 msgstr "Ai'r aelwyd mewn parc yw'ch prif breswylfa?"
 
-#: help_to_heat/frontdoor/schemas.py:146
+#: help_to_heat/frontdoor/schemas.py:147
 msgid "Property address"
 msgstr "Cyfeiriad yr eiddo"
 
-#: help_to_heat/frontdoor/schemas.py:147
+#: help_to_heat/frontdoor/schemas.py:148
 msgid "Council tax band"
 msgstr "Band treth gyngor"
 
-#: help_to_heat/frontdoor/schemas.py:148
+#: help_to_heat/frontdoor/schemas.py:149
 msgid "Energy Performance Certificate"
 msgstr "Dystysgrif Perfformiad Ynni"
 
-#: help_to_heat/frontdoor/schemas.py:150
+#: help_to_heat/frontdoor/schemas.py:151
 msgctxt "summary page"
 msgid "Is anyone in your household receiving any of the following benefits?"
 msgstr ""
 "Oes unrhyw un yn eich aelwyd chi'n cael unrhyw un o'r budd-daliadau canlynol?"
 
-#: help_to_heat/frontdoor/schemas.py:152
+#: help_to_heat/frontdoor/schemas.py:153
 msgid "Annual household income"
 msgstr "Incwm blynyddol yr aelwyd"
 
-#: help_to_heat/frontdoor/schemas.py:153 help_to_heat/frontdoor/schemas.py:154
+#: help_to_heat/frontdoor/schemas.py:154 help_to_heat/frontdoor/schemas.py:155
 #: help_to_heat/templates/frontdoor/epc.html:49
 msgid "Property type"
 msgstr "Math o eiddo"
 
-#: help_to_heat/frontdoor/schemas.py:155
+#: help_to_heat/frontdoor/schemas.py:156
 msgid "Number of bedrooms"
 msgstr "Nifer yr ystafelloedd gwely"
 
-#: help_to_heat/frontdoor/schemas.py:156
+#: help_to_heat/frontdoor/schemas.py:157
 msgid "Property walls"
 msgstr "Waliau'r eiddo"
 
-#: help_to_heat/frontdoor/schemas.py:157
+#: help_to_heat/frontdoor/schemas.py:158
 msgctxt "summary page"
 msgid "Are your walls insulated?"
 msgstr "Ydy'ch waliau wedi'u hinswleiddio?"
 
-#: help_to_heat/frontdoor/schemas.py:158
+#: help_to_heat/frontdoor/schemas.py:159
 msgid "Does this property have a loft?"
 msgstr "Oes gan yr eiddo yma atig?"
 
-#: help_to_heat/frontdoor/schemas.py:159
+#: help_to_heat/frontdoor/schemas.py:160
 #: help_to_heat/templates/frontdoor/loft-access.html:14
 msgid "Is there access to your loft?"
 msgstr "Oes modd mynd i'ch atig?"
 
-#: help_to_heat/frontdoor/schemas.py:160
+#: help_to_heat/frontdoor/schemas.py:161
 msgid "Is there 100mm of insulation in your loft?"
 msgstr "Oes 100mm o inswleiddiad yn eich atig?"
 
-#: help_to_heat/frontdoor/schemas.py:165
+#: help_to_heat/frontdoor/schemas.py:166
 #: help_to_heat/templates/frontdoor/contact-details.html:23
 msgid "First name"
 msgstr "Enw cyntaf"
 
-#: help_to_heat/frontdoor/schemas.py:166
+#: help_to_heat/frontdoor/schemas.py:167
 #: help_to_heat/templates/frontdoor/contact-details.html:26
 msgid "Last name"
 msgstr "Enw olaf"
 
-#: help_to_heat/frontdoor/schemas.py:167
+#: help_to_heat/frontdoor/schemas.py:168
 #: help_to_heat/templates/frontdoor/contact-details.html:39
 msgid "Contact number"
 msgstr "Rhif ffôn"
 
-#: help_to_heat/frontdoor/schemas.py:168
+#: help_to_heat/frontdoor/schemas.py:169
 msgid "Email"
 msgstr "Ebost"
 
-#: help_to_heat/frontdoor/schemas.py:271 help_to_heat/frontdoor/schemas.py:418
+#: help_to_heat/frontdoor/schemas.py:278 help_to_heat/frontdoor/schemas.py:425
 msgid "England"
 msgstr "Lloegr"
 
-#: help_to_heat/frontdoor/schemas.py:275 help_to_heat/frontdoor/schemas.py:419
+#: help_to_heat/frontdoor/schemas.py:282 help_to_heat/frontdoor/schemas.py:426
 msgid "Scotland"
 msgstr "Yr Alban"
 
-#: help_to_heat/frontdoor/schemas.py:279 help_to_heat/frontdoor/schemas.py:420
+#: help_to_heat/frontdoor/schemas.py:286 help_to_heat/frontdoor/schemas.py:427
 msgid "Wales"
 msgstr "Cymru"
 
-#: help_to_heat/frontdoor/schemas.py:283
+#: help_to_heat/frontdoor/schemas.py:290
 msgid "Northern Ireland"
 msgstr "Gogledd Iwerddon"
 
-#: help_to_heat/frontdoor/schemas.py:290 help_to_heat/frontdoor/schemas.py:423
+#: help_to_heat/frontdoor/schemas.py:297 help_to_heat/frontdoor/schemas.py:430
 msgid "Yes, I own my property and live in it"
 msgstr "Ydy, mae'r eiddo'n perthyn i mi a dwi'n byw ynddo"
 
-#: help_to_heat/frontdoor/schemas.py:294 help_to_heat/frontdoor/schemas.py:424
+#: help_to_heat/frontdoor/schemas.py:301 help_to_heat/frontdoor/schemas.py:431
 msgid "No, I am a tenant"
 msgstr "Nac ydy. Tenant ydw i"
 
-#: help_to_heat/frontdoor/schemas.py:296 help_to_heat/frontdoor/schemas.py:304
+#: help_to_heat/frontdoor/schemas.py:303 help_to_heat/frontdoor/schemas.py:311
 msgid ""
 "If you are eligible for a referral through this service, your energy "
 "supplier will need to check that you             have your landlord’s "
@@ -148,207 +148,207 @@ msgstr ""
 "i'ch cyflenwr ynni wirio bod gennych chi ganiatâd eich landlord i osod "
 "unrhyw fesurau arbed ynni yn yr eiddo."
 
-#: help_to_heat/frontdoor/schemas.py:302 help_to_heat/frontdoor/schemas.py:425
+#: help_to_heat/frontdoor/schemas.py:309 help_to_heat/frontdoor/schemas.py:432
 msgid "No, I am a social housing tenant"
 msgstr "Nac ydy. Dwi'n denant tai cymdeithasol"
 
-#: help_to_heat/frontdoor/schemas.py:310 help_to_heat/frontdoor/schemas.py:426
+#: help_to_heat/frontdoor/schemas.py:317 help_to_heat/frontdoor/schemas.py:433
 msgid ""
 "Yes, I am the property owner but I lease the property to one or more tenants"
 msgstr ""
 "Ydy, mae'r eiddo'n perthyn i mi ond dwi'n gosod yr eiddo i un neu ragor o "
 "denantiaid"
 
-#: help_to_heat/frontdoor/schemas.py:316
+#: help_to_heat/frontdoor/schemas.py:323
 msgctxt "park home question option"
 msgid "Yes"
 msgstr "Ydw"
 
-#: help_to_heat/frontdoor/schemas.py:320
+#: help_to_heat/frontdoor/schemas.py:327
 msgctxt "park home question option"
 msgid "No"
 msgstr "Nad ydw"
 
-#: help_to_heat/frontdoor/schemas.py:326 help_to_heat/frontdoor/schemas.py:336
+#: help_to_heat/frontdoor/schemas.py:333 help_to_heat/frontdoor/schemas.py:343
 msgid "Yes"
 msgstr "Ie"
 
-#: help_to_heat/frontdoor/schemas.py:330 help_to_heat/frontdoor/schemas.py:340
+#: help_to_heat/frontdoor/schemas.py:337 help_to_heat/frontdoor/schemas.py:347
 msgid "No"
 msgstr "Nage"
 
-#: help_to_heat/frontdoor/schemas.py:344 help_to_heat/frontdoor/schemas.py:462
-#: help_to_heat/frontdoor/schemas.py:468 help_to_heat/frontdoor/schemas.py:482
-#: help_to_heat/frontdoor/schemas.py:594 help_to_heat/frontdoor/schemas.py:612
-#: help_to_heat/frontdoor/schemas.py:704
+#: help_to_heat/frontdoor/schemas.py:351 help_to_heat/frontdoor/schemas.py:469
+#: help_to_heat/frontdoor/schemas.py:475 help_to_heat/frontdoor/schemas.py:489
+#: help_to_heat/frontdoor/schemas.py:601 help_to_heat/frontdoor/schemas.py:619
+#: help_to_heat/frontdoor/schemas.py:711
 msgid "I do not know"
 msgstr "Wn i ddim"
 
-#: help_to_heat/frontdoor/schemas.py:349
+#: help_to_heat/frontdoor/schemas.py:356
 msgid "Not found"
 msgstr "Heb ei ganfod"
 
-#: help_to_heat/frontdoor/schemas.py:378 help_to_heat/frontdoor/schemas.py:429
+#: help_to_heat/frontdoor/schemas.py:385 help_to_heat/frontdoor/schemas.py:436
 msgctxt "yes no question option"
 msgid "Yes"
 msgstr "Oes"
 
-#: help_to_heat/frontdoor/schemas.py:382 help_to_heat/frontdoor/schemas.py:430
+#: help_to_heat/frontdoor/schemas.py:389 help_to_heat/frontdoor/schemas.py:437
 msgctxt "yes no question option"
 msgid "No"
 msgstr "Nac oes"
 
-#: help_to_heat/frontdoor/schemas.py:388 help_to_heat/frontdoor/schemas.py:433
+#: help_to_heat/frontdoor/schemas.py:395 help_to_heat/frontdoor/schemas.py:440
 msgid "Less than £31,000 a year"
 msgstr "Llai na £31,000 y flwyddyn"
 
-#: help_to_heat/frontdoor/schemas.py:392 help_to_heat/frontdoor/schemas.py:434
+#: help_to_heat/frontdoor/schemas.py:399 help_to_heat/frontdoor/schemas.py:441
 msgid "£31,000 or more a year"
 msgstr "£31,000 y flwyddyn neu ragor"
 
-#: help_to_heat/frontdoor/schemas.py:398 help_to_heat/frontdoor/schemas.py:437
-#: help_to_heat/frontdoor/views.py:262
+#: help_to_heat/frontdoor/schemas.py:405 help_to_heat/frontdoor/schemas.py:444
+#: help_to_heat/frontdoor/views.py:263
 msgid "House"
 msgstr "Tŷ"
 
-#: help_to_heat/frontdoor/schemas.py:402 help_to_heat/frontdoor/schemas.py:438
-#: help_to_heat/frontdoor/views.py:261
+#: help_to_heat/frontdoor/schemas.py:409 help_to_heat/frontdoor/schemas.py:445
+#: help_to_heat/frontdoor/views.py:262
 msgid "Bungalow"
 msgstr "Byngalo"
 
-#: help_to_heat/frontdoor/schemas.py:406 help_to_heat/frontdoor/schemas.py:439
+#: help_to_heat/frontdoor/schemas.py:413 help_to_heat/frontdoor/schemas.py:446
 msgid "Apartment, flat or maisonette"
 msgstr "Rhandy, fflat neu fflat ddeulawr"
 
-#: help_to_heat/frontdoor/schemas.py:411
+#: help_to_heat/frontdoor/schemas.py:418
 msgid "house"
 msgstr "dŷ"
 
-#: help_to_heat/frontdoor/schemas.py:412
+#: help_to_heat/frontdoor/schemas.py:419
 msgid "bungalow"
 msgstr "fyngalo"
 
-#: help_to_heat/frontdoor/schemas.py:413
+#: help_to_heat/frontdoor/schemas.py:420
 msgid "apartment, flat or maisonette"
 msgstr "randy, fflat neu fflat ddeulawr"
 
-#: help_to_heat/frontdoor/schemas.py:440 help_to_heat/frontdoor/views.py:264
+#: help_to_heat/frontdoor/schemas.py:447 help_to_heat/frontdoor/views.py:265
 msgid "Park home"
 msgstr "Cartref mewn parc"
 
-#: help_to_heat/frontdoor/schemas.py:443 help_to_heat/frontdoor/schemas.py:510
-#: help_to_heat/frontdoor/schemas.py:532
+#: help_to_heat/frontdoor/schemas.py:450 help_to_heat/frontdoor/schemas.py:517
+#: help_to_heat/frontdoor/schemas.py:539
 msgid "Detached"
 msgstr "Tŷ sengl"
 
-#: help_to_heat/frontdoor/schemas.py:444 help_to_heat/frontdoor/schemas.py:515
-#: help_to_heat/frontdoor/schemas.py:537
+#: help_to_heat/frontdoor/schemas.py:451 help_to_heat/frontdoor/schemas.py:522
+#: help_to_heat/frontdoor/schemas.py:544
 msgid "Semi-detached"
 msgstr "Tŷ pâr"
 
-#: help_to_heat/frontdoor/schemas.py:445 help_to_heat/frontdoor/schemas.py:520
-#: help_to_heat/frontdoor/schemas.py:542
+#: help_to_heat/frontdoor/schemas.py:452 help_to_heat/frontdoor/schemas.py:527
+#: help_to_heat/frontdoor/schemas.py:549
 msgid "Terraced"
 msgstr "Tŷ teras"
 
-#: help_to_heat/frontdoor/schemas.py:446 help_to_heat/frontdoor/schemas.py:525
-#: help_to_heat/frontdoor/schemas.py:547
+#: help_to_heat/frontdoor/schemas.py:453 help_to_heat/frontdoor/schemas.py:532
+#: help_to_heat/frontdoor/schemas.py:554
 msgid "End terrace"
 msgstr "Tŷ pen teras"
 
-#: help_to_heat/frontdoor/schemas.py:447 help_to_heat/frontdoor/schemas.py:491
+#: help_to_heat/frontdoor/schemas.py:454 help_to_heat/frontdoor/schemas.py:498
 msgid "Top floor"
 msgstr "Llawr uchaf"
 
-#: help_to_heat/frontdoor/schemas.py:448 help_to_heat/frontdoor/schemas.py:496
+#: help_to_heat/frontdoor/schemas.py:455 help_to_heat/frontdoor/schemas.py:503
 msgid "Middle floor"
 msgstr "Llawr canol"
 
-#: help_to_heat/frontdoor/schemas.py:449 help_to_heat/frontdoor/schemas.py:501
+#: help_to_heat/frontdoor/schemas.py:456 help_to_heat/frontdoor/schemas.py:508
 msgid "Ground floor"
 msgstr "Llawr daear"
 
-#: help_to_heat/frontdoor/schemas.py:452 help_to_heat/frontdoor/schemas.py:555
+#: help_to_heat/frontdoor/schemas.py:459 help_to_heat/frontdoor/schemas.py:562
 msgid "Studio"
 msgstr "Stiwdio"
 
-#: help_to_heat/frontdoor/schemas.py:453 help_to_heat/frontdoor/schemas.py:559
+#: help_to_heat/frontdoor/schemas.py:460 help_to_heat/frontdoor/schemas.py:566
 msgid "One bedroom"
 msgstr "Un ystafell wely"
 
-#: help_to_heat/frontdoor/schemas.py:454 help_to_heat/frontdoor/schemas.py:563
+#: help_to_heat/frontdoor/schemas.py:461 help_to_heat/frontdoor/schemas.py:570
 msgid "Two bedrooms"
 msgstr "Dwy ystafell wely"
 
-#: help_to_heat/frontdoor/schemas.py:455 help_to_heat/frontdoor/schemas.py:567
+#: help_to_heat/frontdoor/schemas.py:462 help_to_heat/frontdoor/schemas.py:574
 msgid "Three or more bedrooms"
 msgstr "Tair neu fwy o ystafelloedd gwely"
 
-#: help_to_heat/frontdoor/schemas.py:458 help_to_heat/frontdoor/schemas.py:574
+#: help_to_heat/frontdoor/schemas.py:465 help_to_heat/frontdoor/schemas.py:581
 msgid "Solid walls"
 msgstr "Waliau solet"
 
-#: help_to_heat/frontdoor/schemas.py:459 help_to_heat/frontdoor/schemas.py:578
+#: help_to_heat/frontdoor/schemas.py:466 help_to_heat/frontdoor/schemas.py:585
 msgid "Cavity walls"
 msgstr "Waliau ceudod"
 
-#: help_to_heat/frontdoor/schemas.py:460 help_to_heat/frontdoor/schemas.py:582
+#: help_to_heat/frontdoor/schemas.py:467 help_to_heat/frontdoor/schemas.py:589
 msgid "Mix of solid and cavity walls"
 msgstr "Cymysgedd o waliau solet a waliau ceudod"
 
-#: help_to_heat/frontdoor/schemas.py:461 help_to_heat/frontdoor/schemas.py:586
+#: help_to_heat/frontdoor/schemas.py:468 help_to_heat/frontdoor/schemas.py:593
 msgid "I do not see my option listed"
 msgstr "Dwi ddim yn gweld bod fy opsiwn i wedi'i restru"
 
-#: help_to_heat/frontdoor/schemas.py:465 help_to_heat/frontdoor/schemas.py:600
+#: help_to_heat/frontdoor/schemas.py:472 help_to_heat/frontdoor/schemas.py:607
 msgid "Yes they are all insulated"
 msgstr "Ydyn, maen nhw i gyd wedi'u hinswleiddio"
 
-#: help_to_heat/frontdoor/schemas.py:466 help_to_heat/frontdoor/schemas.py:604
+#: help_to_heat/frontdoor/schemas.py:473 help_to_heat/frontdoor/schemas.py:611
 msgid "Some are insulated, some are not"
 msgstr "Mae rhai wedi'u eu hinswleiddio, mae rhai heb"
 
-#: help_to_heat/frontdoor/schemas.py:467 help_to_heat/frontdoor/schemas.py:608
+#: help_to_heat/frontdoor/schemas.py:474 help_to_heat/frontdoor/schemas.py:615
 msgid "No they are not insulated"
 msgstr "Na, dydyn nhw ddim wedi'u hinswleiddio"
 
-#: help_to_heat/frontdoor/schemas.py:471 help_to_heat/frontdoor/schemas.py:618
+#: help_to_heat/frontdoor/schemas.py:478 help_to_heat/frontdoor/schemas.py:625
 msgid "Yes, I have a loft that has not been converted into a room"
 msgstr "Oes, mae gen i atig sydd heb ei droi'n ystafell"
 
-#: help_to_heat/frontdoor/schemas.py:472 help_to_heat/frontdoor/schemas.py:622
+#: help_to_heat/frontdoor/schemas.py:479 help_to_heat/frontdoor/schemas.py:629
 msgid "No, I do not have a loft or my loft has been converted into a room"
 msgstr "Nac oes, does gen i ddim atig neu mae fy atig i wedi'i droi'n ystafell"
 
-#: help_to_heat/frontdoor/schemas.py:475 help_to_heat/frontdoor/schemas.py:628
+#: help_to_heat/frontdoor/schemas.py:482 help_to_heat/frontdoor/schemas.py:635
 msgid "Yes, there is access to my loft"
 msgstr "Oes, mae modd mynd i'r atig"
 
-#: help_to_heat/frontdoor/schemas.py:476 help_to_heat/frontdoor/schemas.py:632
+#: help_to_heat/frontdoor/schemas.py:483 help_to_heat/frontdoor/schemas.py:639
 msgid "No, there is no access to my loft"
 msgstr "Nac oes, does dim modd mynd i'r atig"
 
-#: help_to_heat/frontdoor/schemas.py:477 help_to_heat/frontdoor/schemas.py:483
+#: help_to_heat/frontdoor/schemas.py:484 help_to_heat/frontdoor/schemas.py:490
 msgid "No loft"
 msgstr "Dim atig"
 
-#: help_to_heat/frontdoor/schemas.py:480 help_to_heat/frontdoor/schemas.py:696
+#: help_to_heat/frontdoor/schemas.py:487 help_to_heat/frontdoor/schemas.py:703
 msgid "I have more than 100mm of loft insulation"
 msgstr "Mae gen i fwy na 100mm o inswleiddiad atig"
 
-#: help_to_heat/frontdoor/schemas.py:481 help_to_heat/frontdoor/schemas.py:700
+#: help_to_heat/frontdoor/schemas.py:488 help_to_heat/frontdoor/schemas.py:707
 msgid "I have up to 100mm of loft insulation"
 msgstr "Mae gen i hyd at 100mm o inswleiddiad atig"
 
-#: help_to_heat/frontdoor/schemas.py:492
+#: help_to_heat/frontdoor/schemas.py:499
 msgid "Sits directly below the roof with no other flat above it"
 msgstr "Yn gorwedd yn union o dan y to heb unrhyw fflat arall uwch ei phen"
 
-#: help_to_heat/frontdoor/schemas.py:497
+#: help_to_heat/frontdoor/schemas.py:504
 msgid "Has another flat above, and another below"
 msgstr "Mae fflat arall uwchben, ac un arall odani"
 
-#: help_to_heat/frontdoor/schemas.py:503
+#: help_to_heat/frontdoor/schemas.py:510
 msgid ""
 "The lowest flat in the building with no flat beneath - typically at street "
 "level but may be a basement"
@@ -356,24 +356,24 @@ msgstr ""
 "Y fflat isaf yn yr adeilad heb fflat odani - fel arfer ar lefel y stryd ond "
 "gall fod yn islawr"
 
-#: help_to_heat/frontdoor/schemas.py:511 help_to_heat/frontdoor/schemas.py:533
+#: help_to_heat/frontdoor/schemas.py:518 help_to_heat/frontdoor/schemas.py:540
 msgid "Does not share any of its walls with another house or building"
 msgstr "Nid yw'n rhannu unrhyw un o'i waliau â thŷ neu adeilad arall"
 
-#: help_to_heat/frontdoor/schemas.py:516 help_to_heat/frontdoor/schemas.py:538
+#: help_to_heat/frontdoor/schemas.py:523 help_to_heat/frontdoor/schemas.py:545
 msgid "Is attached to one other house or building"
 msgstr "Mae wedi'i gysylltu ag un tŷ neu adeilad arall"
 
-#: help_to_heat/frontdoor/schemas.py:521 help_to_heat/frontdoor/schemas.py:543
+#: help_to_heat/frontdoor/schemas.py:528 help_to_heat/frontdoor/schemas.py:550
 msgid "Sits in the middle with a house or building on each side"
 msgstr "Yn sefyll yn y canol gyda thŷ neu adeilad o boptu iddo"
 
-#: help_to_heat/frontdoor/schemas.py:526 help_to_heat/frontdoor/schemas.py:548
+#: help_to_heat/frontdoor/schemas.py:533 help_to_heat/frontdoor/schemas.py:555
 msgid ""
 "Sits at the end of a row of similar houses with one house attached to it"
 msgstr "Yn sefyll ar ben rhes o dai tebyg gydag un tŷ ynghlwm wrtho"
 
-#: help_to_heat/frontdoor/schemas.py:588
+#: help_to_heat/frontdoor/schemas.py:595
 msgid ""
 "Other wall types could include cob walls, timber framed, system built, steel "
 "framed or other non-traditional build types"
@@ -381,173 +381,173 @@ msgstr ""
 "Gallai mathau eraill o waliau gynnwys waliau cob, waliau ffrâm pren, "
 "adeiladu system, fframiau dur neu fathau eraill o adeiladau anhraddodiadol"
 
-#: help_to_heat/frontdoor/schemas.py:649
+#: help_to_heat/frontdoor/schemas.py:656
 msgid "Bulb, now part of Octopus Energy"
 msgstr "Bulb, sydd bellach yn rhan o Octopus"
 
-#: help_to_heat/frontdoor/schemas.py:715
+#: help_to_heat/frontdoor/schemas.py:722
 msgid "Completely agree"
 msgstr "Cytuno'n llwyr"
 
-#: help_to_heat/frontdoor/schemas.py:719
+#: help_to_heat/frontdoor/schemas.py:726
 msgid "Agree"
 msgstr "Cytuno"
 
-#: help_to_heat/frontdoor/schemas.py:723
+#: help_to_heat/frontdoor/schemas.py:730
 msgid "Neutral"
 msgstr "Niwtral"
 
-#: help_to_heat/frontdoor/schemas.py:727
+#: help_to_heat/frontdoor/schemas.py:734
 msgid "Disagree"
 msgstr "Anghytuno"
 
-#: help_to_heat/frontdoor/schemas.py:731
+#: help_to_heat/frontdoor/schemas.py:738
 msgid "Completely disagree"
 msgstr "Anghytuno'n llwyr"
 
-#: help_to_heat/frontdoor/schemas.py:738
+#: help_to_heat/frontdoor/schemas.py:745
 msgid "Very satisfied"
 msgstr "Bodlon iawn"
 
-#: help_to_heat/frontdoor/schemas.py:742
+#: help_to_heat/frontdoor/schemas.py:749
 msgid "Somewhat satisfied"
 msgstr "Eithaf bodlon"
 
-#: help_to_heat/frontdoor/schemas.py:746
+#: help_to_heat/frontdoor/schemas.py:753
 msgid "Neither satisfied nor dissatisfied"
 msgstr "Ddim yn fodlon nac yn anfodlon"
 
-#: help_to_heat/frontdoor/schemas.py:750
+#: help_to_heat/frontdoor/schemas.py:757
 msgid "Somewhat dissatisfied"
 msgstr "Eithaf anfodlon"
 
-#: help_to_heat/frontdoor/schemas.py:754
+#: help_to_heat/frontdoor/schemas.py:761
 msgid "Very dissatisfied"
 msgstr "Anfodlon iawn"
 
-#: help_to_heat/frontdoor/schemas.py:761
+#: help_to_heat/frontdoor/schemas.py:768
 msgid "To find ways to reduce my energy bills"
 msgstr "Dod o hyd i ffyrdd i leihau fy miliau ynni"
 
-#: help_to_heat/frontdoor/schemas.py:765
+#: help_to_heat/frontdoor/schemas.py:772
 msgid "To find ways to reduce my carbon emissions"
 msgstr "Dod o hyd i ffyrdd i leihau fy allyriadau carbon"
 
-#: help_to_heat/frontdoor/schemas.py:769
+#: help_to_heat/frontdoor/schemas.py:776
 msgid "To find ways to install a specific measure in my home"
 msgstr "Dod o hyd i ffyrdd o osod mesur penodol yn fy nghartref"
 
-#: help_to_heat/frontdoor/schemas.py:773
+#: help_to_heat/frontdoor/schemas.py:780
 msgid "To find ways to improve my EPC rating"
 msgstr "Dod o hyd i ffyrdd i wella fy sgôr EPC"
 
-#: help_to_heat/frontdoor/schemas.py:777
+#: help_to_heat/frontdoor/schemas.py:784
 msgid "To find ways to make my home more comfortable"
 msgstr "Dod o hyd i ffyrdd i wneud fy nghartref yn fwy cyffyrddus"
 
-#: help_to_heat/frontdoor/schemas.py:781
+#: help_to_heat/frontdoor/schemas.py:788
 msgid "Other"
 msgstr "Arall"
 
-#: help_to_heat/frontdoor/schemas.py:869
+#: help_to_heat/frontdoor/schemas.py:876
 msgid "Enter a valid UK postcode"
 msgstr "Rhowch god post dilys yn y Deyrnas Unedig"
 
-#: help_to_heat/frontdoor/schemas.py:874
+#: help_to_heat/frontdoor/schemas.py:881
 msgid "Invalid email format"
 msgstr "Fformat ebost annilys"
 
-#: help_to_heat/frontdoor/schemas.py:884 help_to_heat/frontdoor/schemas.py:888
+#: help_to_heat/frontdoor/schemas.py:891 help_to_heat/frontdoor/schemas.py:895
 msgid ""
 "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 "
 "0192"
 msgstr "Rhowch rif ffôn, fel 01632 960 001, 07700 900 982 neu +44 808 157 0192"
 
-#: help_to_heat/frontdoor/schemas.py:900
+#: help_to_heat/frontdoor/schemas.py:907
 msgid "Energy Company Obligation 4"
 msgstr "Rhwymedigaeth Cwmni Ynni 4"
 
-#: help_to_heat/frontdoor/schemas.py:901
+#: help_to_heat/frontdoor/schemas.py:908
 msgid "Great British Insulation Scheme"
 msgstr "Cynllun Inswleiddio Mawr Prydain"
 
-#: help_to_heat/frontdoor/views.py:201
+#: help_to_heat/frontdoor/views.py:202
 msgid "Select where the property is located"
 msgstr "Dewiswch beth yw lleoliad yr eiddo"
 
-#: help_to_heat/frontdoor/views.py:202
+#: help_to_heat/frontdoor/views.py:203
 msgid "Select if you own the property"
 msgstr "Dewiswch os yw'r eiddo'n perthyn i chi"
 
-#: help_to_heat/frontdoor/views.py:203
+#: help_to_heat/frontdoor/views.py:204
 msgid "Select if you live in a park home"
 msgstr "Dewiswch os ydych chi’n byw mewn aelwyd mewn parc "
 
-#: help_to_heat/frontdoor/views.py:204
+#: help_to_heat/frontdoor/views.py:205
 msgid "Select if the park home is your main residence"
 msgstr "Dewiswch os eich aelwyd mewn parc yw’ch prif breswylfa "
 
-#: help_to_heat/frontdoor/views.py:205
+#: help_to_heat/frontdoor/views.py:206
 msgid "Enter building name or number"
 msgstr "Rhowch enw neu rif yr adeilad"
 
-#: help_to_heat/frontdoor/views.py:206
+#: help_to_heat/frontdoor/views.py:207
 msgid "Enter Address line 1"
 msgstr "Rhowch linell 1 y cyfeiriad"
 
-#: help_to_heat/frontdoor/views.py:207
+#: help_to_heat/frontdoor/views.py:208
 msgid "Enter a postcode"
 msgstr "Rhowch god post"
 
-#: help_to_heat/frontdoor/views.py:208 help_to_heat/frontdoor/views.py:209
+#: help_to_heat/frontdoor/views.py:209 help_to_heat/frontdoor/views.py:210
 msgid ""
 "Select your address, or I can't find my address if your address is not listed"
 msgstr ""
 "Dewiswch eich cyfeiriad, neu ‘Dwi’n methu gweld fy nghyfeiriad i’ os nad "
 "yw'ch cyfeiriad wedi'i restru"
 
-#: help_to_heat/frontdoor/views.py:210
+#: help_to_heat/frontdoor/views.py:211
 msgid "Enter your Town or city"
 msgstr "Rhowch eich tref neu'ch dinas"
 
-#: help_to_heat/frontdoor/views.py:211
+#: help_to_heat/frontdoor/views.py:212
 msgid "Please confirm that you want to submit another referral"
 msgstr "A wnewch chi gadarnhau eich bod eisiau cyflwyno atgyfeiriad arall"
 
-#: help_to_heat/frontdoor/views.py:212
+#: help_to_heat/frontdoor/views.py:213
 msgid "Enter the Council Tax Band of the property"
 msgstr "Rhowch Fand Treth Gyngor yr eiddo"
 
-#: help_to_heat/frontdoor/views.py:213
+#: help_to_heat/frontdoor/views.py:214
 msgid "Select if your EPC rating is correct or not, or that you do not know"
 msgstr ""
 "Dewiswch a yw eich cyfraddiad EPC yn gywir neu beidio, neu nad ydych chi'n "
 "gwybod"
 
-#: help_to_heat/frontdoor/views.py:214
+#: help_to_heat/frontdoor/views.py:215
 msgid ""
 "Select if anyone in your household is receiving any benefits listed below"
 msgstr ""
 "Dewiswch a oes unrhyw un yn eich aelwyd chi'n cael unrhyw un neu ragor o'r "
 "budd-daliadau isod"
 
-#: help_to_heat/frontdoor/views.py:215
+#: help_to_heat/frontdoor/views.py:216
 msgid "Select your household income"
 msgstr "Dewiswch incwm eich aelwyd"
 
-#: help_to_heat/frontdoor/views.py:216 help_to_heat/frontdoor/views.py:217
+#: help_to_heat/frontdoor/views.py:217 help_to_heat/frontdoor/views.py:218
 msgid "Select your property type"
 msgstr "Dewiswch eich math o eiddo"
 
-#: help_to_heat/frontdoor/views.py:218
+#: help_to_heat/frontdoor/views.py:219
 msgid "Select the number of bedrooms the property has"
 msgstr "Dewiswch nifer yr ystafelloedd gwely sydd gan yr eiddo"
 
-#: help_to_heat/frontdoor/views.py:219
+#: help_to_heat/frontdoor/views.py:220
 msgid "Select the type of walls the property has"
 msgstr "Dewiswch y math o waliau sydd gan yr eiddo"
 
-#: help_to_heat/frontdoor/views.py:220
+#: help_to_heat/frontdoor/views.py:221
 msgid ""
 "Select if the walls of the property are insulated or not, or if you do not "
 "know"
@@ -555,40 +555,40 @@ msgstr ""
 "Dewiswch a ydy waliau'r eiddo wedi'u hinswleiddio neu beidio, neu nad ydych "
 "chi'n gwybod"
 
-#: help_to_heat/frontdoor/views.py:221
+#: help_to_heat/frontdoor/views.py:222
 msgid "Select if you have a loft that has been converted into a room or not"
 msgstr "Dewiswch a oes gennych chi atig sydd wedi'i droi'n ystafell neu beidio"
 
-#: help_to_heat/frontdoor/views.py:222
+#: help_to_heat/frontdoor/views.py:223
 msgid "Select whether or not you have access to the loft"
 msgstr "Dewiswch a oes modd mynd i'r atig neu beidio"
 
-#: help_to_heat/frontdoor/views.py:223
+#: help_to_heat/frontdoor/views.py:224
 msgid "Select whether or not your loft is fully insulated"
 msgstr "Dewiswch a ydy'ch atig wedi'i inswleiddio'n llawn neu beidio"
 
-#: help_to_heat/frontdoor/views.py:224
+#: help_to_heat/frontdoor/views.py:225
 #: help_to_heat/templates/frontdoor/supplier.html:14
 msgid "Select your home energy supplier from the list below"
 msgstr "Dewiswch eich cyflenwr ynni cartref chi o blith y rhestr isod"
 
-#: help_to_heat/frontdoor/views.py:225
+#: help_to_heat/frontdoor/views.py:226
 msgid "Enter your first name"
 msgstr "Rhowch eich enw cyntaf"
 
-#: help_to_heat/frontdoor/views.py:226
+#: help_to_heat/frontdoor/views.py:227
 msgid "Enter your last name"
 msgstr "Rhowch eich enw olaf"
 
-#: help_to_heat/frontdoor/views.py:227
+#: help_to_heat/frontdoor/views.py:228
 msgid "Enter your email address"
 msgstr "Rhowch eich cyfeiriad ebost"
 
-#: help_to_heat/frontdoor/views.py:228
+#: help_to_heat/frontdoor/views.py:229
 msgid "Enter your contact number"
 msgstr "Rhowch eich rhif ffôn"
 
-#: help_to_heat/frontdoor/views.py:230 help_to_heat/frontdoor/views.py:233
+#: help_to_heat/frontdoor/views.py:231 help_to_heat/frontdoor/views.py:234
 msgid ""
 "Please confirm that you agree to the use of your information by checking "
 "this box"
@@ -596,7 +596,7 @@ msgstr ""
 "Rhowch gadarnhad eich bod yn cytuno i'ch gwybodaeth gael ei defnyddio drwy "
 "roi tic yn y blwch hwn"
 
-#: help_to_heat/frontdoor/views.py:236
+#: help_to_heat/frontdoor/views.py:237
 msgid ""
 "Please confirm that you understand your home must be sufficiently ventilated "
 "before any insulation is installed"
@@ -604,7 +604,7 @@ msgstr ""
 "Rhowch gadarnhad eich bod yn deall bod rhaid bod i’ch cartref fod wedi’i "
 "awyru’n ddigonol cyn i unrhyw inswleiddiad gael ei osod"
 
-#: help_to_heat/frontdoor/views.py:240
+#: help_to_heat/frontdoor/views.py:241
 msgid ""
 "Please confirm that you understand you may be required to contribute towards "
 "the cost of installing insulation"
@@ -612,63 +612,63 @@ msgstr ""
 "Rhowch gadarnhad eich bod yn deall y gall fod angen ichi gyfrannu at gost "
 "gosod inswleiddiad"
 
-#: help_to_heat/frontdoor/views.py:245
+#: help_to_heat/frontdoor/views.py:246
 msgid "January"
 msgstr "Ionawr"
 
-#: help_to_heat/frontdoor/views.py:246
+#: help_to_heat/frontdoor/views.py:247
 msgid "February"
 msgstr "Chwefror"
 
-#: help_to_heat/frontdoor/views.py:247
+#: help_to_heat/frontdoor/views.py:248
 msgid "March"
 msgstr "Mawrth"
 
-#: help_to_heat/frontdoor/views.py:248
+#: help_to_heat/frontdoor/views.py:249
 msgid "April"
 msgstr "Ebrill"
 
-#: help_to_heat/frontdoor/views.py:249
+#: help_to_heat/frontdoor/views.py:250
 msgid "May"
 msgstr "Mai"
 
-#: help_to_heat/frontdoor/views.py:250
+#: help_to_heat/frontdoor/views.py:251
 msgid "June"
 msgstr "Mehefin"
 
-#: help_to_heat/frontdoor/views.py:251
+#: help_to_heat/frontdoor/views.py:252
 msgid "July"
 msgstr "Gorffennaf"
 
-#: help_to_heat/frontdoor/views.py:252
+#: help_to_heat/frontdoor/views.py:253
 msgid "August"
 msgstr "Awst"
 
-#: help_to_heat/frontdoor/views.py:253
+#: help_to_heat/frontdoor/views.py:254
 msgid "September"
 msgstr "Medi"
 
-#: help_to_heat/frontdoor/views.py:254
+#: help_to_heat/frontdoor/views.py:255
 msgid "October"
 msgstr "Hydref"
 
-#: help_to_heat/frontdoor/views.py:255
+#: help_to_heat/frontdoor/views.py:256
 msgid "November"
 msgstr "Tachwedd"
 
-#: help_to_heat/frontdoor/views.py:256
+#: help_to_heat/frontdoor/views.py:257
 msgid "December"
 msgstr "Rhagfyr"
 
-#: help_to_heat/frontdoor/views.py:260
+#: help_to_heat/frontdoor/views.py:261
 msgid "Flat"
 msgstr "Fflat"
 
-#: help_to_heat/frontdoor/views.py:263
+#: help_to_heat/frontdoor/views.py:264
 msgid "Maisonette"
 msgstr "Fflat deulawr"
 
-#: help_to_heat/frontdoor/views.py:646 help_to_heat/frontdoor/views.py:716
+#: help_to_heat/frontdoor/views.py:655 help_to_heat/frontdoor/views.py:725
 msgid "I cannot find my address, I want to enter it manually"
 msgstr "Dwi'n methu gweld fy nghyfeiriad i. Hoffwn ei roi fy hunan."
 

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 
 from help_to_heat.frontdoor import interface
+from help_to_heat.frontdoor.consts import country_page
 from help_to_heat.frontdoor.mock_epc_api import (
     MockEPCApi,
     MockEPCApiWithEPCC,
@@ -2103,6 +2104,20 @@ def test_epc_page_shows_epc_info():
 
     assert page.has_one("p:contains('Date of issue')")
     assert page.has_one("p:contains('23 July 2010')")
+
+
+@unittest.mock.patch("help_to_heat.frontdoor.interface.EPCApi", MockEPCApi)
+def test_success_page_still_shows_if_journey_cannot_reach_it():
+    supplier = "Utilita"
+
+    session_id, _ = _do_happy_flow(supplier=supplier)
+
+    utils.delete_answer_in_session(session_id, country_page)
+
+    client = utils.get_client()
+    page = client.get(f"/{session_id}/success").follow()
+
+    assert page.has_one(f"h1:contains('Your details have been submitted to {supplier}')")
 
 
 def _setup_client_and_page():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ import testino
 from django.conf import settings
 from django.utils import timezone
 
-from help_to_heat import portal, wsgi
+from help_to_heat import frontdoor, portal, wsgi
 from help_to_heat.portal import models
 
 __here__ = pathlib.Path(__file__).parent
@@ -175,3 +175,7 @@ def create_referral(session_id, data=None, supplier="British Gas", creation_time
     referral = portal.models.Referral.objects.get()
     referral.created_at = creation_timestamp
     referral.save()
+
+
+def delete_answer_in_session(session_id, page_name):
+    frontdoor.models.Answer.objects.get(session_id=session_id, page_name=page_name).delete()


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1347)

# Description

adds a routing exception for the success page

in this case, the exception does nothing, so opted to mark it as `None`. could have a different way of marking that there's no previous page for `success`?

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to Python files (even if not changing any content strings), I have run `make extract-translations`
