### PR TITLE
PC-1413: Remove "I don't know" option from EPC question

### DIFF
--- a/help_to_heat/frontdoor/schemas.py
+++ b/help_to_heat/frontdoor/schemas.py
@@ -44,7 +44,6 @@ from help_to_heat.frontdoor.consts import (
     epc_rating_field,
     epc_select_manual_page,
     epc_select_page,
-    field_dont_know,
     field_no,
     field_yes,
     household_income_field,
@@ -345,10 +344,6 @@ epc_display_options_map = (
     {
         "value": field_no,
         "label": _("No"),
-    },
-    {
-        "value": field_dont_know,
-        "label": _("I do not know"),
     },
 )
 epc_validation_options_map = epc_display_options_map + (

--- a/help_to_heat/locale/cy/LC_MESSAGES/django.po
+++ b/help_to_heat/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-07 16:40+0000\n"
+"POT-Creation-Date: 2024-11-12 17:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,126 +19,126 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
 "11) ? 2 : 3;\n"
 
-#: help_to_heat/frontdoor/schemas.py:142
+#: help_to_heat/frontdoor/schemas.py:141
 msgid "Country of property"
 msgstr "Gwlad yr eiddo"
 
-#: help_to_heat/frontdoor/schemas.py:143 help_to_heat/frontdoor/schemas.py:165
+#: help_to_heat/frontdoor/schemas.py:142 help_to_heat/frontdoor/schemas.py:164
 msgid "Energy supplier"
 msgstr "Cyflenwr ynni"
 
-#: help_to_heat/frontdoor/schemas.py:144
+#: help_to_heat/frontdoor/schemas.py:143
 msgctxt "summary page"
 msgid "Do you own the property?"
 msgstr "Ydy'r eiddo yn perthyn i chi?"
 
-#: help_to_heat/frontdoor/schemas.py:145
+#: help_to_heat/frontdoor/schemas.py:144
 #: help_to_heat/templates/frontdoor/park-home.html:14
 msgid "Do you live in a park home?"
 msgstr "Ydych chi'n byw mewn aelwyd mewn parc?"
 
-#: help_to_heat/frontdoor/schemas.py:146
+#: help_to_heat/frontdoor/schemas.py:145
 #: help_to_heat/templates/frontdoor/park-home-main-residence.html:14
 msgid "Is the park home your main residence?"
 msgstr "Ai'r aelwyd mewn parc yw'ch prif breswylfa?"
 
-#: help_to_heat/frontdoor/schemas.py:147
+#: help_to_heat/frontdoor/schemas.py:146
 msgid "Property address"
 msgstr "Cyfeiriad yr eiddo"
 
-#: help_to_heat/frontdoor/schemas.py:148
+#: help_to_heat/frontdoor/schemas.py:147
 msgid "Council tax band"
 msgstr "Band treth gyngor"
 
-#: help_to_heat/frontdoor/schemas.py:149
+#: help_to_heat/frontdoor/schemas.py:148
 msgid "Energy Performance Certificate"
 msgstr "Dystysgrif Perfformiad Ynni"
 
-#: help_to_heat/frontdoor/schemas.py:151
+#: help_to_heat/frontdoor/schemas.py:150
 msgctxt "summary page"
 msgid "Is anyone in your household receiving any of the following benefits?"
 msgstr ""
 "Oes unrhyw un yn eich aelwyd chi'n cael unrhyw un o'r budd-daliadau canlynol?"
 
-#: help_to_heat/frontdoor/schemas.py:153
+#: help_to_heat/frontdoor/schemas.py:152
 msgid "Annual household income"
 msgstr "Incwm blynyddol yr aelwyd"
 
-#: help_to_heat/frontdoor/schemas.py:154 help_to_heat/frontdoor/schemas.py:155
+#: help_to_heat/frontdoor/schemas.py:153 help_to_heat/frontdoor/schemas.py:154
 #: help_to_heat/templates/frontdoor/epc.html:49
 msgid "Property type"
 msgstr "Math o eiddo"
 
-#: help_to_heat/frontdoor/schemas.py:156
+#: help_to_heat/frontdoor/schemas.py:155
 msgid "Number of bedrooms"
 msgstr "Nifer yr ystafelloedd gwely"
 
-#: help_to_heat/frontdoor/schemas.py:157
+#: help_to_heat/frontdoor/schemas.py:156
 msgid "Property walls"
 msgstr "Waliau'r eiddo"
 
-#: help_to_heat/frontdoor/schemas.py:158
+#: help_to_heat/frontdoor/schemas.py:157
 msgctxt "summary page"
 msgid "Are your walls insulated?"
 msgstr "Ydy'ch waliau wedi'u hinswleiddio?"
 
-#: help_to_heat/frontdoor/schemas.py:159
+#: help_to_heat/frontdoor/schemas.py:158
 msgid "Does this property have a loft?"
 msgstr "Oes gan yr eiddo yma atig?"
 
-#: help_to_heat/frontdoor/schemas.py:160
+#: help_to_heat/frontdoor/schemas.py:159
 #: help_to_heat/templates/frontdoor/loft-access.html:14
 msgid "Is there access to your loft?"
 msgstr "Oes modd mynd i'ch atig?"
 
-#: help_to_heat/frontdoor/schemas.py:161
+#: help_to_heat/frontdoor/schemas.py:160
 msgid "Is there 100mm of insulation in your loft?"
 msgstr "Oes 100mm o inswleiddiad yn eich atig?"
 
-#: help_to_heat/frontdoor/schemas.py:166
+#: help_to_heat/frontdoor/schemas.py:165
 #: help_to_heat/templates/frontdoor/contact-details.html:23
 msgid "First name"
 msgstr "Enw cyntaf"
 
-#: help_to_heat/frontdoor/schemas.py:167
+#: help_to_heat/frontdoor/schemas.py:166
 #: help_to_heat/templates/frontdoor/contact-details.html:26
 msgid "Last name"
 msgstr "Enw olaf"
 
-#: help_to_heat/frontdoor/schemas.py:168
+#: help_to_heat/frontdoor/schemas.py:167
 #: help_to_heat/templates/frontdoor/contact-details.html:39
 msgid "Contact number"
 msgstr "Rhif ffôn"
 
-#: help_to_heat/frontdoor/schemas.py:169
+#: help_to_heat/frontdoor/schemas.py:168
 msgid "Email"
 msgstr "Ebost"
 
-#: help_to_heat/frontdoor/schemas.py:278 help_to_heat/frontdoor/schemas.py:425
+#: help_to_heat/frontdoor/schemas.py:277 help_to_heat/frontdoor/schemas.py:420
 msgid "England"
 msgstr "Lloegr"
 
-#: help_to_heat/frontdoor/schemas.py:282 help_to_heat/frontdoor/schemas.py:426
+#: help_to_heat/frontdoor/schemas.py:281 help_to_heat/frontdoor/schemas.py:421
 msgid "Scotland"
 msgstr "Yr Alban"
 
-#: help_to_heat/frontdoor/schemas.py:286 help_to_heat/frontdoor/schemas.py:427
+#: help_to_heat/frontdoor/schemas.py:285 help_to_heat/frontdoor/schemas.py:422
 msgid "Wales"
 msgstr "Cymru"
 
-#: help_to_heat/frontdoor/schemas.py:290
+#: help_to_heat/frontdoor/schemas.py:289
 msgid "Northern Ireland"
 msgstr "Gogledd Iwerddon"
 
-#: help_to_heat/frontdoor/schemas.py:297 help_to_heat/frontdoor/schemas.py:430
+#: help_to_heat/frontdoor/schemas.py:296 help_to_heat/frontdoor/schemas.py:425
 msgid "Yes, I own my property and live in it"
 msgstr "Ydy, mae'r eiddo'n perthyn i mi a dwi'n byw ynddo"
 
-#: help_to_heat/frontdoor/schemas.py:301 help_to_heat/frontdoor/schemas.py:431
+#: help_to_heat/frontdoor/schemas.py:300 help_to_heat/frontdoor/schemas.py:426
 msgid "No, I am a tenant"
 msgstr "Nac ydy. Tenant ydw i"
 
-#: help_to_heat/frontdoor/schemas.py:303 help_to_heat/frontdoor/schemas.py:311
+#: help_to_heat/frontdoor/schemas.py:302 help_to_heat/frontdoor/schemas.py:310
 msgid ""
 "If you are eligible for a referral through this service, your energy "
 "supplier will need to check that you             have your landlord’s "
@@ -148,207 +148,206 @@ msgstr ""
 "i'ch cyflenwr ynni wirio bod gennych chi ganiatâd eich landlord i osod "
 "unrhyw fesurau arbed ynni yn yr eiddo."
 
-#: help_to_heat/frontdoor/schemas.py:309 help_to_heat/frontdoor/schemas.py:432
+#: help_to_heat/frontdoor/schemas.py:308 help_to_heat/frontdoor/schemas.py:427
 msgid "No, I am a social housing tenant"
 msgstr "Nac ydy. Dwi'n denant tai cymdeithasol"
 
-#: help_to_heat/frontdoor/schemas.py:317 help_to_heat/frontdoor/schemas.py:433
+#: help_to_heat/frontdoor/schemas.py:316 help_to_heat/frontdoor/schemas.py:428
 msgid ""
 "Yes, I am the property owner but I lease the property to one or more tenants"
 msgstr ""
 "Ydy, mae'r eiddo'n perthyn i mi ond dwi'n gosod yr eiddo i un neu ragor o "
 "denantiaid"
 
-#: help_to_heat/frontdoor/schemas.py:323
+#: help_to_heat/frontdoor/schemas.py:322
 msgctxt "park home question option"
 msgid "Yes"
 msgstr "Ydw"
 
-#: help_to_heat/frontdoor/schemas.py:327
+#: help_to_heat/frontdoor/schemas.py:326
 msgctxt "park home question option"
 msgid "No"
 msgstr "Nad ydw"
 
-#: help_to_heat/frontdoor/schemas.py:333 help_to_heat/frontdoor/schemas.py:343
+#: help_to_heat/frontdoor/schemas.py:332 help_to_heat/frontdoor/schemas.py:342
 msgid "Yes"
 msgstr "Ie"
 
-#: help_to_heat/frontdoor/schemas.py:337 help_to_heat/frontdoor/schemas.py:347
+#: help_to_heat/frontdoor/schemas.py:336 help_to_heat/frontdoor/schemas.py:346
 msgid "No"
 msgstr "Nage"
 
-#: help_to_heat/frontdoor/schemas.py:351 help_to_heat/frontdoor/schemas.py:469
-#: help_to_heat/frontdoor/schemas.py:475 help_to_heat/frontdoor/schemas.py:489
-#: help_to_heat/frontdoor/schemas.py:601 help_to_heat/frontdoor/schemas.py:619
-#: help_to_heat/frontdoor/schemas.py:711
-msgid "I do not know"
-msgstr "Wn i ddim"
-
-#: help_to_heat/frontdoor/schemas.py:356
+#: help_to_heat/frontdoor/schemas.py:351
 msgid "Not found"
 msgstr "Heb ei ganfod"
 
-#: help_to_heat/frontdoor/schemas.py:385 help_to_heat/frontdoor/schemas.py:436
+#: help_to_heat/frontdoor/schemas.py:380 help_to_heat/frontdoor/schemas.py:431
 msgctxt "yes no question option"
 msgid "Yes"
 msgstr "Oes"
 
-#: help_to_heat/frontdoor/schemas.py:389 help_to_heat/frontdoor/schemas.py:437
+#: help_to_heat/frontdoor/schemas.py:384 help_to_heat/frontdoor/schemas.py:432
 msgctxt "yes no question option"
 msgid "No"
 msgstr "Nac oes"
 
-#: help_to_heat/frontdoor/schemas.py:395 help_to_heat/frontdoor/schemas.py:440
+#: help_to_heat/frontdoor/schemas.py:390 help_to_heat/frontdoor/schemas.py:435
 msgid "Less than £31,000 a year"
 msgstr "Llai na £31,000 y flwyddyn"
 
-#: help_to_heat/frontdoor/schemas.py:399 help_to_heat/frontdoor/schemas.py:441
+#: help_to_heat/frontdoor/schemas.py:394 help_to_heat/frontdoor/schemas.py:436
 msgid "£31,000 or more a year"
 msgstr "£31,000 y flwyddyn neu ragor"
 
-#: help_to_heat/frontdoor/schemas.py:405 help_to_heat/frontdoor/schemas.py:444
+#: help_to_heat/frontdoor/schemas.py:400 help_to_heat/frontdoor/schemas.py:439
 #: help_to_heat/frontdoor/views.py:263
 msgid "House"
 msgstr "Tŷ"
 
-#: help_to_heat/frontdoor/schemas.py:409 help_to_heat/frontdoor/schemas.py:445
+#: help_to_heat/frontdoor/schemas.py:404 help_to_heat/frontdoor/schemas.py:440
 #: help_to_heat/frontdoor/views.py:262
 msgid "Bungalow"
 msgstr "Byngalo"
 
-#: help_to_heat/frontdoor/schemas.py:413 help_to_heat/frontdoor/schemas.py:446
+#: help_to_heat/frontdoor/schemas.py:408 help_to_heat/frontdoor/schemas.py:441
 msgid "Apartment, flat or maisonette"
 msgstr "Rhandy, fflat neu fflat ddeulawr"
 
-#: help_to_heat/frontdoor/schemas.py:418
+#: help_to_heat/frontdoor/schemas.py:413
 msgid "house"
 msgstr "dŷ"
 
-#: help_to_heat/frontdoor/schemas.py:419
+#: help_to_heat/frontdoor/schemas.py:414
 msgid "bungalow"
 msgstr "fyngalo"
 
-#: help_to_heat/frontdoor/schemas.py:420
+#: help_to_heat/frontdoor/schemas.py:415
 msgid "apartment, flat or maisonette"
 msgstr "randy, fflat neu fflat ddeulawr"
 
-#: help_to_heat/frontdoor/schemas.py:447 help_to_heat/frontdoor/views.py:265
+#: help_to_heat/frontdoor/schemas.py:442 help_to_heat/frontdoor/views.py:265
 msgid "Park home"
 msgstr "Cartref mewn parc"
 
-#: help_to_heat/frontdoor/schemas.py:450 help_to_heat/frontdoor/schemas.py:517
-#: help_to_heat/frontdoor/schemas.py:539
+#: help_to_heat/frontdoor/schemas.py:445 help_to_heat/frontdoor/schemas.py:512
+#: help_to_heat/frontdoor/schemas.py:534
 msgid "Detached"
 msgstr "Tŷ sengl"
 
-#: help_to_heat/frontdoor/schemas.py:451 help_to_heat/frontdoor/schemas.py:522
-#: help_to_heat/frontdoor/schemas.py:544
+#: help_to_heat/frontdoor/schemas.py:446 help_to_heat/frontdoor/schemas.py:517
+#: help_to_heat/frontdoor/schemas.py:539
 msgid "Semi-detached"
 msgstr "Tŷ pâr"
 
-#: help_to_heat/frontdoor/schemas.py:452 help_to_heat/frontdoor/schemas.py:527
-#: help_to_heat/frontdoor/schemas.py:549
+#: help_to_heat/frontdoor/schemas.py:447 help_to_heat/frontdoor/schemas.py:522
+#: help_to_heat/frontdoor/schemas.py:544
 msgid "Terraced"
 msgstr "Tŷ teras"
 
-#: help_to_heat/frontdoor/schemas.py:453 help_to_heat/frontdoor/schemas.py:532
-#: help_to_heat/frontdoor/schemas.py:554
+#: help_to_heat/frontdoor/schemas.py:448 help_to_heat/frontdoor/schemas.py:527
+#: help_to_heat/frontdoor/schemas.py:549
 msgid "End terrace"
 msgstr "Tŷ pen teras"
 
-#: help_to_heat/frontdoor/schemas.py:454 help_to_heat/frontdoor/schemas.py:498
+#: help_to_heat/frontdoor/schemas.py:449 help_to_heat/frontdoor/schemas.py:493
 msgid "Top floor"
 msgstr "Llawr uchaf"
 
-#: help_to_heat/frontdoor/schemas.py:455 help_to_heat/frontdoor/schemas.py:503
+#: help_to_heat/frontdoor/schemas.py:450 help_to_heat/frontdoor/schemas.py:498
 msgid "Middle floor"
 msgstr "Llawr canol"
 
-#: help_to_heat/frontdoor/schemas.py:456 help_to_heat/frontdoor/schemas.py:508
+#: help_to_heat/frontdoor/schemas.py:451 help_to_heat/frontdoor/schemas.py:503
 msgid "Ground floor"
 msgstr "Llawr daear"
 
-#: help_to_heat/frontdoor/schemas.py:459 help_to_heat/frontdoor/schemas.py:562
+#: help_to_heat/frontdoor/schemas.py:454 help_to_heat/frontdoor/schemas.py:557
 msgid "Studio"
 msgstr "Stiwdio"
 
-#: help_to_heat/frontdoor/schemas.py:460 help_to_heat/frontdoor/schemas.py:566
+#: help_to_heat/frontdoor/schemas.py:455 help_to_heat/frontdoor/schemas.py:561
 msgid "One bedroom"
 msgstr "Un ystafell wely"
 
-#: help_to_heat/frontdoor/schemas.py:461 help_to_heat/frontdoor/schemas.py:570
+#: help_to_heat/frontdoor/schemas.py:456 help_to_heat/frontdoor/schemas.py:565
 msgid "Two bedrooms"
 msgstr "Dwy ystafell wely"
 
-#: help_to_heat/frontdoor/schemas.py:462 help_to_heat/frontdoor/schemas.py:574
+#: help_to_heat/frontdoor/schemas.py:457 help_to_heat/frontdoor/schemas.py:569
 msgid "Three or more bedrooms"
 msgstr "Tair neu fwy o ystafelloedd gwely"
 
-#: help_to_heat/frontdoor/schemas.py:465 help_to_heat/frontdoor/schemas.py:581
+#: help_to_heat/frontdoor/schemas.py:460 help_to_heat/frontdoor/schemas.py:576
 msgid "Solid walls"
 msgstr "Waliau solet"
 
-#: help_to_heat/frontdoor/schemas.py:466 help_to_heat/frontdoor/schemas.py:585
+#: help_to_heat/frontdoor/schemas.py:461 help_to_heat/frontdoor/schemas.py:580
 msgid "Cavity walls"
 msgstr "Waliau ceudod"
 
-#: help_to_heat/frontdoor/schemas.py:467 help_to_heat/frontdoor/schemas.py:589
+#: help_to_heat/frontdoor/schemas.py:462 help_to_heat/frontdoor/schemas.py:584
 msgid "Mix of solid and cavity walls"
 msgstr "Cymysgedd o waliau solet a waliau ceudod"
 
-#: help_to_heat/frontdoor/schemas.py:468 help_to_heat/frontdoor/schemas.py:593
+#: help_to_heat/frontdoor/schemas.py:463 help_to_heat/frontdoor/schemas.py:588
 msgid "I do not see my option listed"
 msgstr "Dwi ddim yn gweld bod fy opsiwn i wedi'i restru"
 
-#: help_to_heat/frontdoor/schemas.py:472 help_to_heat/frontdoor/schemas.py:607
+#: help_to_heat/frontdoor/schemas.py:464 help_to_heat/frontdoor/schemas.py:470
+#: help_to_heat/frontdoor/schemas.py:484 help_to_heat/frontdoor/schemas.py:596
+#: help_to_heat/frontdoor/schemas.py:614 help_to_heat/frontdoor/schemas.py:706
+msgid "I do not know"
+msgstr "Wn i ddim"
+
+#: help_to_heat/frontdoor/schemas.py:467 help_to_heat/frontdoor/schemas.py:602
 msgid "Yes they are all insulated"
 msgstr "Ydyn, maen nhw i gyd wedi'u hinswleiddio"
 
-#: help_to_heat/frontdoor/schemas.py:473 help_to_heat/frontdoor/schemas.py:611
+#: help_to_heat/frontdoor/schemas.py:468 help_to_heat/frontdoor/schemas.py:606
 msgid "Some are insulated, some are not"
 msgstr "Mae rhai wedi'u eu hinswleiddio, mae rhai heb"
 
-#: help_to_heat/frontdoor/schemas.py:474 help_to_heat/frontdoor/schemas.py:615
+#: help_to_heat/frontdoor/schemas.py:469 help_to_heat/frontdoor/schemas.py:610
 msgid "No they are not insulated"
 msgstr "Na, dydyn nhw ddim wedi'u hinswleiddio"
 
-#: help_to_heat/frontdoor/schemas.py:478 help_to_heat/frontdoor/schemas.py:625
+#: help_to_heat/frontdoor/schemas.py:473 help_to_heat/frontdoor/schemas.py:620
 msgid "Yes, I have a loft that has not been converted into a room"
 msgstr "Oes, mae gen i atig sydd heb ei droi'n ystafell"
 
-#: help_to_heat/frontdoor/schemas.py:479 help_to_heat/frontdoor/schemas.py:629
+#: help_to_heat/frontdoor/schemas.py:474 help_to_heat/frontdoor/schemas.py:624
 msgid "No, I do not have a loft or my loft has been converted into a room"
 msgstr "Nac oes, does gen i ddim atig neu mae fy atig i wedi'i droi'n ystafell"
 
-#: help_to_heat/frontdoor/schemas.py:482 help_to_heat/frontdoor/schemas.py:635
+#: help_to_heat/frontdoor/schemas.py:477 help_to_heat/frontdoor/schemas.py:630
 msgid "Yes, there is access to my loft"
 msgstr "Oes, mae modd mynd i'r atig"
 
-#: help_to_heat/frontdoor/schemas.py:483 help_to_heat/frontdoor/schemas.py:639
+#: help_to_heat/frontdoor/schemas.py:478 help_to_heat/frontdoor/schemas.py:634
 msgid "No, there is no access to my loft"
 msgstr "Nac oes, does dim modd mynd i'r atig"
 
-#: help_to_heat/frontdoor/schemas.py:484 help_to_heat/frontdoor/schemas.py:490
+#: help_to_heat/frontdoor/schemas.py:479 help_to_heat/frontdoor/schemas.py:485
 msgid "No loft"
 msgstr "Dim atig"
 
-#: help_to_heat/frontdoor/schemas.py:487 help_to_heat/frontdoor/schemas.py:703
+#: help_to_heat/frontdoor/schemas.py:482 help_to_heat/frontdoor/schemas.py:698
 msgid "I have more than 100mm of loft insulation"
 msgstr "Mae gen i fwy na 100mm o inswleiddiad atig"
 
-#: help_to_heat/frontdoor/schemas.py:488 help_to_heat/frontdoor/schemas.py:707
+#: help_to_heat/frontdoor/schemas.py:483 help_to_heat/frontdoor/schemas.py:702
 msgid "I have up to 100mm of loft insulation"
 msgstr "Mae gen i hyd at 100mm o inswleiddiad atig"
 
-#: help_to_heat/frontdoor/schemas.py:499
+#: help_to_heat/frontdoor/schemas.py:494
 msgid "Sits directly below the roof with no other flat above it"
 msgstr "Yn gorwedd yn union o dan y to heb unrhyw fflat arall uwch ei phen"
 
-#: help_to_heat/frontdoor/schemas.py:504
+#: help_to_heat/frontdoor/schemas.py:499
 msgid "Has another flat above, and another below"
 msgstr "Mae fflat arall uwchben, ac un arall odani"
 
-#: help_to_heat/frontdoor/schemas.py:510
+#: help_to_heat/frontdoor/schemas.py:505
 msgid ""
 "The lowest flat in the building with no flat beneath - typically at street "
 "level but may be a basement"
@@ -356,24 +355,24 @@ msgstr ""
 "Y fflat isaf yn yr adeilad heb fflat odani - fel arfer ar lefel y stryd ond "
 "gall fod yn islawr"
 
-#: help_to_heat/frontdoor/schemas.py:518 help_to_heat/frontdoor/schemas.py:540
+#: help_to_heat/frontdoor/schemas.py:513 help_to_heat/frontdoor/schemas.py:535
 msgid "Does not share any of its walls with another house or building"
 msgstr "Nid yw'n rhannu unrhyw un o'i waliau â thŷ neu adeilad arall"
 
-#: help_to_heat/frontdoor/schemas.py:523 help_to_heat/frontdoor/schemas.py:545
+#: help_to_heat/frontdoor/schemas.py:518 help_to_heat/frontdoor/schemas.py:540
 msgid "Is attached to one other house or building"
 msgstr "Mae wedi'i gysylltu ag un tŷ neu adeilad arall"
 
-#: help_to_heat/frontdoor/schemas.py:528 help_to_heat/frontdoor/schemas.py:550
+#: help_to_heat/frontdoor/schemas.py:523 help_to_heat/frontdoor/schemas.py:545
 msgid "Sits in the middle with a house or building on each side"
 msgstr "Yn sefyll yn y canol gyda thŷ neu adeilad o boptu iddo"
 
-#: help_to_heat/frontdoor/schemas.py:533 help_to_heat/frontdoor/schemas.py:555
+#: help_to_heat/frontdoor/schemas.py:528 help_to_heat/frontdoor/schemas.py:550
 msgid ""
 "Sits at the end of a row of similar houses with one house attached to it"
 msgstr "Yn sefyll ar ben rhes o dai tebyg gydag un tŷ ynghlwm wrtho"
 
-#: help_to_heat/frontdoor/schemas.py:595
+#: help_to_heat/frontdoor/schemas.py:590
 msgid ""
 "Other wall types could include cob walls, timber framed, system built, steel "
 "framed or other non-traditional build types"
@@ -381,93 +380,93 @@ msgstr ""
 "Gallai mathau eraill o waliau gynnwys waliau cob, waliau ffrâm pren, "
 "adeiladu system, fframiau dur neu fathau eraill o adeiladau anhraddodiadol"
 
-#: help_to_heat/frontdoor/schemas.py:656
+#: help_to_heat/frontdoor/schemas.py:651
 msgid "Bulb, now part of Octopus Energy"
 msgstr "Bulb, sydd bellach yn rhan o Octopus"
 
-#: help_to_heat/frontdoor/schemas.py:722
+#: help_to_heat/frontdoor/schemas.py:717
 msgid "Completely agree"
 msgstr "Cytuno'n llwyr"
 
-#: help_to_heat/frontdoor/schemas.py:726
+#: help_to_heat/frontdoor/schemas.py:721
 msgid "Agree"
 msgstr "Cytuno"
 
-#: help_to_heat/frontdoor/schemas.py:730
+#: help_to_heat/frontdoor/schemas.py:725
 msgid "Neutral"
 msgstr "Niwtral"
 
-#: help_to_heat/frontdoor/schemas.py:734
+#: help_to_heat/frontdoor/schemas.py:729
 msgid "Disagree"
 msgstr "Anghytuno"
 
-#: help_to_heat/frontdoor/schemas.py:738
+#: help_to_heat/frontdoor/schemas.py:733
 msgid "Completely disagree"
 msgstr "Anghytuno'n llwyr"
 
-#: help_to_heat/frontdoor/schemas.py:745
+#: help_to_heat/frontdoor/schemas.py:740
 msgid "Very satisfied"
 msgstr "Bodlon iawn"
 
-#: help_to_heat/frontdoor/schemas.py:749
+#: help_to_heat/frontdoor/schemas.py:744
 msgid "Somewhat satisfied"
 msgstr "Eithaf bodlon"
 
-#: help_to_heat/frontdoor/schemas.py:753
+#: help_to_heat/frontdoor/schemas.py:748
 msgid "Neither satisfied nor dissatisfied"
 msgstr "Ddim yn fodlon nac yn anfodlon"
 
-#: help_to_heat/frontdoor/schemas.py:757
+#: help_to_heat/frontdoor/schemas.py:752
 msgid "Somewhat dissatisfied"
 msgstr "Eithaf anfodlon"
 
-#: help_to_heat/frontdoor/schemas.py:761
+#: help_to_heat/frontdoor/schemas.py:756
 msgid "Very dissatisfied"
 msgstr "Anfodlon iawn"
 
-#: help_to_heat/frontdoor/schemas.py:768
+#: help_to_heat/frontdoor/schemas.py:763
 msgid "To find ways to reduce my energy bills"
 msgstr "Dod o hyd i ffyrdd i leihau fy miliau ynni"
 
-#: help_to_heat/frontdoor/schemas.py:772
+#: help_to_heat/frontdoor/schemas.py:767
 msgid "To find ways to reduce my carbon emissions"
 msgstr "Dod o hyd i ffyrdd i leihau fy allyriadau carbon"
 
-#: help_to_heat/frontdoor/schemas.py:776
+#: help_to_heat/frontdoor/schemas.py:771
 msgid "To find ways to install a specific measure in my home"
 msgstr "Dod o hyd i ffyrdd o osod mesur penodol yn fy nghartref"
 
-#: help_to_heat/frontdoor/schemas.py:780
+#: help_to_heat/frontdoor/schemas.py:775
 msgid "To find ways to improve my EPC rating"
 msgstr "Dod o hyd i ffyrdd i wella fy sgôr EPC"
 
-#: help_to_heat/frontdoor/schemas.py:784
+#: help_to_heat/frontdoor/schemas.py:779
 msgid "To find ways to make my home more comfortable"
 msgstr "Dod o hyd i ffyrdd i wneud fy nghartref yn fwy cyffyrddus"
 
-#: help_to_heat/frontdoor/schemas.py:788
+#: help_to_heat/frontdoor/schemas.py:783
 msgid "Other"
 msgstr "Arall"
 
-#: help_to_heat/frontdoor/schemas.py:876
+#: help_to_heat/frontdoor/schemas.py:871
 msgid "Enter a valid UK postcode"
 msgstr "Rhowch god post dilys yn y Deyrnas Unedig"
 
-#: help_to_heat/frontdoor/schemas.py:881
+#: help_to_heat/frontdoor/schemas.py:876
 msgid "Invalid email format"
 msgstr "Fformat ebost annilys"
 
-#: help_to_heat/frontdoor/schemas.py:891 help_to_heat/frontdoor/schemas.py:895
+#: help_to_heat/frontdoor/schemas.py:886 help_to_heat/frontdoor/schemas.py:890
 msgid ""
 "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 "
 "0192"
 msgstr "Rhowch rif ffôn, fel 01632 960 001, 07700 900 982 neu +44 808 157 0192"
 
-#: help_to_heat/frontdoor/schemas.py:907
+#: help_to_heat/frontdoor/schemas.py:902
 msgid "Energy Company Obligation 4"
 msgstr "Rhwymedigaeth Cwmni Ynni 4"
 
-#: help_to_heat/frontdoor/schemas.py:908
+#: help_to_heat/frontdoor/schemas.py:903
 msgid "Great British Insulation Scheme"
 msgstr "Cynllun Inswleiddio Mawr Prydain"
 
@@ -668,7 +667,7 @@ msgstr "Fflat"
 msgid "Maisonette"
 msgstr "Fflat deulawr"
 
-#: help_to_heat/frontdoor/views.py:655 help_to_heat/frontdoor/views.py:725
+#: help_to_heat/frontdoor/views.py:661 help_to_heat/frontdoor/views.py:731
 msgid "I cannot find my address, I want to enter it manually"
 msgstr "Dwi'n methu gweld fy nghyfeiriad i. Hoffwn ei roi fy hunan."
 


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1413)

# Description

Removed "I don't know" option from EPC question.

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to Python files (even if not changing any content strings), I have run `make extract-translations`
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVK4AgQ3E=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent

# Screenshots

![{F1284D3D-2B5E-4C0E-A971-31C9DC5B0A35}](https://github.com/user-attachments/assets/ba0dd363-7ece-4735-b336-86ccf6dec654)

