### PR TITLE
PC-1425: Fix for adding a space after address search first line can show no results

### DIFF
--- a/help_to_heat/frontdoor/mock_epc_api.py
+++ b/help_to_heat/frontdoor/mock_epc_api.py
@@ -77,6 +77,17 @@ class MockRecommendationsTransientInternalServerErrorEPCApi(MockEPCApi):
         return super().get_epc_recommendations(lmk_key)
 
 
+def get_mock_epc_api_expecting_address_and_postcode(check_address, check_postcode):
+    class MockEpcApiExpectingAddressAndPostcode(MockEPCApi):
+        def search_epc_details(self, address, postcode):
+            if address != check_address or postcode != check_postcode:
+                raise NotFoundRequestException()
+            else:
+                return super().search_epc_details(address, postcode)
+
+    return MockEpcApiExpectingAddressAndPostcode
+
+
 class UnauthorizedRequestException(requests.exceptions.RequestException):
     def __init__(self):
         self.response = requests.Response()

--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -619,8 +619,13 @@ class AddressView(PageView):
         reset_epc_details(session_id)
         session_data = interface.api.session.get_session(session_id)
         country = session_data.get(country_field)
-        building_name_or_number = data.get(address_building_name_or_number_field)
-        postcode = data.get(address_postcode_field)
+        building_name_or_number = data.get(address_building_name_or_number_field).strip()
+        postcode = data.get(address_postcode_field).strip()
+
+        # overwrite the answers with stripped ones
+        data[address_building_name_or_number_field] = building_name_or_number
+        data[address_postcode_field] = postcode
+
         try:
             if country != country_field_scotland:
                 address_and_lmk_details = interface.api.epc.get_address_and_epc_lmk(building_name_or_number, postcode)
@@ -716,9 +721,9 @@ class EpcSelectView(PageView):
 @register_page(address_select_page)
 class AddressSelectView(PageView):
     def build_extra_context(self, request, session_id, page_name, data, is_change_page):
-        data = interface.api.session.get_answer(session_id, address_page)
-        building_name_or_number = data[address_building_name_or_number_field]
-        postcode = data[address_postcode_field]
+        address_data = interface.api.session.get_answer(session_id, address_page)
+        building_name_or_number = address_data[address_building_name_or_number_field]
+        postcode = address_data[address_postcode_field]
         addresses = interface.api.address.find_addresses(building_name_or_number, postcode)
 
         uprn_options = tuple(

--- a/help_to_heat/locale/cy/LC_MESSAGES/django.po
+++ b/help_to_heat/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-25 15:19+0000\n"
+"POT-Creation-Date: 2024-11-28 09:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -671,7 +671,7 @@ msgstr "Fflat"
 msgid "Maisonette"
 msgstr "Fflat deulawr"
 
-#: help_to_heat/frontdoor/views.py:667 help_to_heat/frontdoor/views.py:735
+#: help_to_heat/frontdoor/views.py:672 help_to_heat/frontdoor/views.py:740
 msgid "I cannot find my address, I want to enter it manually"
 msgstr "Dwi'n methu gweld fy nghyfeiriad i. Hoffwn ei roi fy hunan."
 

--- a/tests/test_frontdoor.py
+++ b/tests/test_frontdoor.py
@@ -24,6 +24,7 @@ from help_to_heat.frontdoor.mock_epc_api import (
     MockRecommendationsInternalServerErrorEPCApi,
     MockRecommendationsNotFoundEPCApi,
     MockRecommendationsTransientInternalServerErrorEPCApi,
+    get_mock_epc_api_expecting_address_and_postcode,
 )
 from help_to_heat.frontdoor.mock_os_api import EmptyOSApi, MockOSApi
 from help_to_heat.portal import models
@@ -2269,6 +2270,43 @@ def test_success_page_still_shows_if_journey_cannot_reach_it():
     page = client.get(f"/{session_id}/success").follow()
 
     assert page.has_one(f"h1:contains('Your details have been submitted to {supplier}')")
+
+
+@unittest.mock.patch(
+    "help_to_heat.frontdoor.interface.EPCApi", get_mock_epc_api_expecting_address_and_postcode("22", "FL23 4JA")
+)
+def test_epc_api_is_called_with_trimmed_address_and_postcode():
+    client = utils.get_client()
+    page = client.get("/start")
+    assert page.status_code == 302
+    page = page.follow()
+
+    assert page.status_code == 200
+    session_id = page.path.split("/")[1]
+    assert uuid.UUID(session_id)
+    _check_page = _make_check_page(session_id)
+
+    form = page.get_form()
+    form["country"] = "England"
+    page = form.submit().follow()
+
+    form = page.get_form()
+    form["supplier"] = "Utilita"
+    page = form.submit().follow()
+
+    assert page.has_text("Do you own the property?")
+    page = _check_page(page, "own-property", "own_property", "Yes, I own my property and live in it")
+
+    assert page.has_text("Do you live in a park home")
+    page = _check_page(page, "park-home", "park_home", "No")
+
+    form = page.get_form()
+    form["building_name_or_number"] = "  22  "
+    form["postcode"] = "  FL23 4JA  "
+    page = form.submit().follow()
+
+    assert page.has_one("label:contains('22 Acacia Avenue, Upper Wellgood, Fulchester, FL23 4JA')")
+    assert page.has_one("label:contains('11 Acacia Avenue, Upper Wellgood, Fulchester, FL23 4JA')")
 
 
 def _setup_client_and_page():


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1425)

# Description

adds a `.strip()` before passing off address and postcode to OS Places API

this should remove all kinds of whitespace

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to Python files (even if not changing any content strings), I have run `make extract-translations`
