### PR TITLE
PC-1294: Fix CSRF Fail

### DIFF
--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -258,7 +258,8 @@ OPEN_EPC_API_BASE_URL = env.str("OPEN_EPC_API_BASE_URL")
 
 TOTP_ISSUER = "Help to Heat Supplier Portal"
 
-CSRF_TRUSTED_ORIGINS = [BASE_URL]
+# origins don't have a trailing slash, the BASE_URL does so must be trimmed
+CSRF_TRUSTED_ORIGINS = [BASE_URL.rstrip("/")]
 
 if not DEBUG:
     SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1294)

# Description

use an explicit csrf origin. this should match the provided failing origin: `https://dev.check-eligibility-for-gb-insulation-scheme.service.gov.uk`

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to Python files (even if not changing any content strings), I have run `make extract-translations`
