### PR TITLE
Redirect base URL to start page when running locally

### DIFF
--- a/help_to_heat/frontdoor/views.py
+++ b/help_to_heat/frontdoor/views.py
@@ -296,8 +296,10 @@ def register_page(name):
 
 
 def redirect_to_homepage_view(request):
-    next_url = govuk_start_page_url
-    return redirect(next_url)
+    if settings.DEBUG:
+        return start_view(request)
+    else:
+        return redirect(govuk_start_page_url)
 
 
 def start_view(request):

--- a/help_to_heat/locale/cy/LC_MESSAGES/django.po
+++ b/help_to_heat/locale/cy/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-19 12:28+0000\n"
+"POT-Creation-Date: 2024-12-31 16:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -677,11 +677,11 @@ msgstr "Fflat"
 msgid "Maisonette"
 msgstr "Fflat deulawr"
 
-#: help_to_heat/frontdoor/views.py:594
+#: help_to_heat/frontdoor/views.py:596
 msgid "My energy supplier is not listed"
 msgstr "Dyw fy nghyflenwr ynni i ddim wedi'i restru"
 
-#: help_to_heat/frontdoor/views.py:707 help_to_heat/frontdoor/views.py:773
+#: help_to_heat/frontdoor/views.py:709 help_to_heat/frontdoor/views.py:775
 msgid "I cannot find my address, I want to enter it manually"
 msgstr "Dwi'n methu gweld fy nghyfeiriad i. Hoffwn ei roi fy hunan."
 


### PR DESCRIPTION
# Description

Similar to how we have on WH:LG now, to get it off my to-do list

# Checklist

- [ ] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [ ] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to Python files (even if not changing any content strings), I have run `make extract-translations`
- [ ] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVK4AgQ3E=/)
- [ ] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent