### PR TITLE
PC-1696: Handle unresponsive API

### DIFF
--- a/help_to_heat/frontdoor/epc_api.py
+++ b/help_to_heat/frontdoor/epc_api.py
@@ -4,6 +4,8 @@ import urllib.parse
 import requests
 from django.conf import settings
 
+from help_to_heat.utils import default_api_timeout
+
 logger = logging.getLogger(__name__)
 
 
@@ -31,7 +33,7 @@ class EPCApi:
 
     def __api_call(self, url):
         headers = self._basic_auth_header()
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=default_api_timeout)
         response.raise_for_status()
         if len(response.content) == 0:
             return None

--- a/help_to_heat/frontdoor/os_api.py
+++ b/help_to_heat/frontdoor/os_api.py
@@ -4,6 +4,8 @@ from http import HTTPStatus
 
 import requests
 
+from help_to_heat.utils import default_api_timeout
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,7 +42,7 @@ class OSApi:
         return []
 
     def perform_request(self, url):
-        response = requests.get(url)
+        response = requests.get(url, timeout=default_api_timeout)
         response.raise_for_status()
         json_response = response.json()
 

--- a/help_to_heat/utils.py
+++ b/help_to_heat/utils.py
@@ -266,3 +266,6 @@ def get_most_recent_epc_per_uprn(address_and_lmk_details):
         most_recent_address_and_lmk_details.append(latest_epc)
 
     return most_recent_address_and_lmk_details
+
+
+default_api_timeout = 10


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1696)

# Description

adds timeouts to our two API calls in the projects.

went with 10 seconds as a reasonable amount of time to expect a user to wait

an example error we would expect to see is

```
[15/Jan/2025 12:06:07,473] [ERROR] An error occurred: HTTPSConnectionPool(host='epc.opendatacommunities.org', port=443): Read timed out. (read timeout=0.01)
2025-01-15T12:06:07.493417887Z Traceback (most recent call last):
2025-01-15T12:06:07.493426387Z   File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 386, in _make_request
2025-01-15T12:06:07.493450989Z     self._validate_conn(conn)
2025-01-15T12:06:07.493453989Z   File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 1042, in _validate_conn
2025-01-15T12:06:07.493456489Z     conn.connect()
2025-01-15T12:06:07.493458889Z   File "/usr/local/lib/python3.11/site-packages/urllib3/connection.py", line 414, in connect
2025-01-15T12:06:07.493461390Z     self.sock = ssl_wrap_socket(
2025-01-15T12:06:07.493463890Z                 ^^^^^^^^^^^^^^^^
2025-01-15T12:06:07.493466090Z   File "/usr/local/lib/python3.11/site-packages/urllib3/util/ssl_.py", line 449, in ssl_wrap_socket
2025-01-15T12:06:07.493468590Z     ssl_sock = _ssl_wrap_socket_impl(
2025-01-15T12:06:07.493470990Z                ^^^^^^^^^^^^^^^^^^^^^^
2025-01-15T12:06:07.493473190Z   File "/usr/local/lib/python3.11/site-packages/urllib3/util/ssl_.py", line 493, in _ssl_wrap_socket_impl
2025-01-15T12:06:07.493475591Z     return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
2025-01-15T12:06:07.493477991Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-01-15T12:06:07.493480291Z   File "/usr/local/lib/python3.11/ssl.py", line 517, in wrap_socket
2025-01-15T12:06:07.493482791Z     return self.sslsocket_class._create(
2025-01-15T12:06:07.493485191Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-01-15T12:06:07.493487491Z   File "/usr/local/lib/python3.11/ssl.py", line 1104, in _create
2025-01-15T12:06:07.493489892Z     self.do_handshake()
2025-01-15T12:06:07.493492192Z   File "/usr/local/lib/python3.11/ssl.py", line 1382, in do_handshake
2025-01-15T12:06:07.493494492Z     self._sslobj.do_handshake()
2025-01-15T12:06:07.493496892Z TimeoutError: _ssl.c:989: The handshake operation timed out
```

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to Python files (even if not changing any content strings), I have run `make extract-translations`
