### PR TITLE
PC-1702: Remove unused allauth app

### DIFF
--- a/help_to_heat/settings.py
+++ b/help_to_heat/settings.py
@@ -49,7 +49,6 @@ INSTALLED_APPS = [
     "rest_framework",
     "allauth",
     "allauth.account",
-    "allauth.socialaccount",
     "debug_toolbar",
     "django.contrib.admin",
     "django.contrib.auth",


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1702)

# Description

as of 0.62.0 it's a separate package for social account support which we don't install https://docs.allauth.org/en/latest/release-notes/recent.html#id58

we don't use the social account (third party login integration) anyway