### PR TITLE
PC-1762: Switch to a non-root user in our container

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -35,6 +35,9 @@ RUN pip install poetry && \
 
 COPY ./ /app/
 
+RUN groupadd -r appuser && useradd -r -g appuser appuser && chown -R appuser:appuser /app
+USER appuser
+
 RUN \
     DJANGO_SETTINGS_MODULE=help_to_heat.settings_base \
     DJANGO_SECRET_KEY="temp" \


### PR DESCRIPTION
# Description

adds a user to the container dockerfile

this must appear after copying the app so the user can be given ownership of it

this must appear before the `collectstatic` line else the user won't own the result files

to flag, after this is merged it may be necessary to delete your 'staticfiles' folder locally. the start script will regenerate this with the correct permissions when next run

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
