### PR TITLE
PC-NONE: Document approaches to line endings on the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To update Python to a newer version, you will need to:
 
 On GBIS many files use LF line endings. If your git `core.autocrlf` config setting is `true` then these files will be normalised to CRLF on commit.
 This is fine for most files, but for the `*.sh` files in the `docker` folder these files **must** be LF for local development to work.
+Otherwise, you will see a `Illegal option -o errexit` error.
 
 Double-check your `docker` folder in the repo and verify that the shell files are LF.
 If not, you will need to run `git config core.autocrlf false` and change the line endings to LF.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ To update Python to a newer version, you will need to:
 - Run `poetry lock` to generate an updated `pyproject.toml`.
 - Rebuild the app and check it functions.
 
+## Line Endings
+
+On GBIS many files use LF line endings. If your git `core.autocrlf` config setting is `true` then these files will be normalised to CRLF on commit.
+This is fine for most files, but for the `*.sh` files in the `docker` folder these files **must** be LF for local development to work.
+
+Double-check your `docker` folder in the repo and verify that the shell files are LF.
+If not, you will need to run `git config core.autocrlf false` and change the line endings to LF.
+
 ## Translations
 
 ### Summary


### PR DESCRIPTION
common issue with local dev on GBIS is the docker files being CRLF rather than LF